### PR TITLE
Fix invisible cafe health drink placement

### DIFF
--- a/pc_port/build_gen/extracted_data/map0_s01_extracted_data.c
+++ b/pc_port/build_gen/extracted_data/map0_s01_extracted_data.c
@@ -21,7 +21,7 @@
 #include "game.h"             /* VECTOR3 */
 #include "bodyprog/bodyprog.h" /* s_AnmHeader, s_WorldObjectModel etc. (shared.h prereqs) */
 #include "main/fsqueue.h"     /* s_FsImageDesc (background_draw.h prereq) */
-#include "maps/shared.h"      /* s_WorldObjectPose (D_800DE12C/D_800DE140) */
+#include "maps/shared.h"
 
 // 0x800DDC98  size 0xE0 (224 bytes) — fallback room-index grid for
 // Map_RoomIdxGet (same street layout as map0_s00; byte-identical table).
@@ -71,15 +71,15 @@ const u16 D_800DE124[4] = { 0x102A, 0x1004, 0x1005, 0x0000 };
 // PSX aliases this into g_Cutscene_MapMsgAudioCmds[46..47]; PC duplicates.
 const u16 D_800DE128[2] = { 0x1005, 0x0000 };
 
-// 0x800DE12C  s_WorldObjectPose — health drink #0 placement.
-// PSX aliases into g_Cutscene_MapMsgAudioCmds[48..]; PC stores as proper struct.
-s_WorldObjectPose D_800DE12C = {
+// 0x800DE12C  s_Pose — health drink #0 placement.
+// PSX aliases into g_Cutscene_MapMsgAudioCmds[48..]; PC stores as a plain pose.
+s_Pose D_800DE12C = {
     .position   = { 0x00005199, (s32)0xFFFFF000, 0x00111B33 },
     .rotation = { 0, 0x024F, 0 },
 };
 
-// 0x800DE140  s_WorldObjectPose — health drink #1 placement.
-s_WorldObjectPose D_800DE140 = {
+// 0x800DE140  s_Pose — health drink #1 placement.
+s_Pose D_800DE140 = {
     .position   = { 0x00004F33, (s32)0xFFFFF000, 0x0010B800 },
     .rotation = { 0, 0x0311, 0 },
 };
@@ -99,4 +99,3 @@ s32 g_Cutscene_Timer = 0;
 
 // 0x800E23A0  size 0xF0 (240 bytes)
 u8 g_Cutscene_MapMsgAudioIdx = 0x00;
-

--- a/pc_port/tools/check_map0_s01_pose_types.py
+++ b/pc_port/tools/check_map0_s01_pose_types.py
@@ -1,0 +1,52 @@
+"""Check cafe health drink placement symbols use the map-declared pose layout."""
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HEADER = ROOT / "include" / "maps" / "map0" / "map0_s01.h"
+DATA = ROOT / "pc_port" / "build_gen" / "extracted_data" / "map0_s01_extracted_data.c"
+SYMBOLS = ("D_800DE12C", "D_800DE140")
+
+
+def find_type(pattern, text, symbol):
+    match = re.search(pattern.format(symbol=re.escape(symbol)), text, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def main() -> int:
+    header_text = HEADER.read_text(encoding="utf-8")
+    data_text = DATA.read_text(encoding="utf-8")
+    errors = []
+
+    for symbol in SYMBOLS:
+        declared_type = find_type(r"extern\s+(\w+)\s+{symbol}\s*;", header_text, symbol)
+        defined_type = find_type(r"^\s*(\w+)\s+{symbol}\s*=", data_text, symbol)
+
+        if declared_type is None:
+            errors.append(f"{symbol}: no extern declaration found in {HEADER}")
+            continue
+        if defined_type is None:
+            errors.append(f"{symbol}: no definition found in {DATA}")
+            continue
+        if defined_type != declared_type:
+            errors.append(
+                f"{symbol}: extracted data defines {defined_type}, "
+                f"but the map declares {declared_type}"
+            )
+        if defined_type != "s_Pose":
+            errors.append(f"{symbol}: cafe item placement must be s_Pose, not {defined_type}")
+
+    if errors:
+        print("map0_s01 pose layout check failed:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print("map0_s01 cafe health drink pose layout check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The cafe health drink placement symbols are declared as s_Pose in the map header and are passed directly to WorldGfx_ObjectAdd.

The PC extracted-data definition used s_WorldObjectPose instead, which has a different layout because it includes embedded world-object model data before the position. As a result, the pickup trigger still worked, but the renderer read the wrong bytes for the item position, making the health drink invisible.

Define the cafe health drink placements as s_Pose and add a small regression check to catch future declaration/definition layout mismatches.