### PR TITLE
Build: fix map DLL compilation so non-intro maps load

### DIFF
--- a/pc_port/maps/CMakeLists.txt
+++ b/pc_port/maps/CMakeLists.txt
@@ -75,6 +75,27 @@ function(add_map_overlay MAP_NAME MAP_DEFINE)
         -include "${CMAKE_SOURCE_DIR}/include/map_dll_fixups.h"
     )
 
+    # Same warning suppressions as the main exe (CMakeLists.txt). The decomp
+    # has many un-finalized signatures (e.g. q3_12* vs q19_12*, void(*)() vs
+    # typed fn ptrs); GCC 14 promotes -Wincompatible-pointer-types and friends
+    # to hard errors by default, which breaks the map DLL build even though the
+    # exe (which carries these flags) compiles the same sources fine. Without
+    # this, no map except the built-in map0_s00 can be built, so every map
+    # transition crashes on a NULL overlay header.
+    if(NOT MSVC)
+        target_compile_options(${MAP_NAME} PRIVATE
+            -Wno-incompatible-pointer-types
+            -Wno-discarded-qualifiers
+            -Wno-builtin-declaration-mismatch
+            -Wno-int-to-pointer-cast
+            -Wno-pointer-to-int-cast
+            -Wno-sign-compare
+            -Wno-missing-braces
+            -Wno-unused-variable
+            -Wno-unused-function
+        )
+    endif()
+
     # Link against the main executable's import library.
     # Map DLL functions call back into game code (g_SysWork, etc.),
     # so they need the exe's exported symbols to resolve at load time.


### PR DESCRIPTION
Forgot pushing this one! @SlickAmogus  please check it out and include if you can friend!

Only map0_s00 is compiled into the exe; every other map loads from maps/<name>.dll. The map DLL targets never carried the warning suppressions the main exe uses, so a GCC 14 upgrade (which promotes -Wincompatible-pointer-types and friends to hard errors) broke the entire -DSH_BUILD_MAP_DLLS=ON build on the decomp's un-finalized signatures (e.g. q3_12* vs q19_12*). With no DLLs built, the first map transition (e.g. the intro death -> cafe wake-up = map0_s01) dereferenced a NULL overlay header and hard-crashed (0xC0000005 reading 0x4).

Apply the same -Wno-* suppressions as the main exe to every map DLL target. All 42 map DLLs now build, unblocking the whole game past the intro alley.