### PR TITLE
macOS (Apple Silicon) build support

### DIFF
--- a/pc_port/CMakeLists.txt
+++ b/pc_port/CMakeLists.txt
@@ -155,6 +155,12 @@ list(FILTER PC_PORT_SOURCES EXCLUDE REGEX "map_overlay_stub\\.c$")
 # (src/bodyprog/bodyprog_combat_8005BF38.c) now provides target selection.
 list(FILTER PC_PORT_SOURCES EXCLUDE REGEX "combat_target\\.c$")
 
+# pc_crash.c is Windows-only (SEH crash telemetry); exclude on non-Windows platforms.
+# dll_loader.c and fmv_player.cpp both have #ifdef _WIN32 guards and work on POSIX.
+if(NOT WIN32)
+    list(FILTER PC_PORT_SOURCES EXCLUDE REGEX "pc_crash\\.c$")
+endif()
+
 # Windows: compile the .rc so the exe carries an application icon (Explorer,
 # taskbar, title bar). windres resolves the ICON path relative to the .rc dir.
 if(WIN32)
@@ -250,6 +256,10 @@ target_include_directories(SilentHillPC PRIVATE
     "${PSYCROSS_DIR}/include/psx"
     "${PSYCROSS_DIR}/include"
 )
+# OpenAL headers for xa_player.c and any other game code using AL directly
+if(OPENAL_INCLUDE_DIR)
+    target_include_directories(SilentHillPC PRIVATE "${OPENAL_INCLUDE_DIR}")
+endif()
 
 # =============================================================================
 # libjpeg (for FMV playback - MJPG decoding)
@@ -311,6 +321,14 @@ else()
         -Wno-discarded-qualifiers
         -Wno-builtin-declaration-mismatch
     )
+    if(APPLE)
+        target_compile_options(SilentHillPC PRIVATE
+            -Wno-implicit-function-declaration
+            -Wno-ignored-qualifiers
+            -Wno-int-conversion
+            -Wno-return-mismatch
+        )
+    endif()
 endif()
 
 # =============================================================================

--- a/pc_port/build.sh
+++ b/pc_port/build.sh
@@ -4,52 +4,80 @@
 # Prerequisites:
 #   - CMake 3.16+
 #   - GCC or Clang
-#   - SDL2 development libraries (libsdl2-dev)
-#   - OpenAL-soft development libraries (libopenal-dev)
-#   - OpenGL development headers (libgl-dev)
+#   - SDL2 development libraries
+#   - OpenAL-soft development libraries
+#   - OpenGL development headers
 #
-# PsyCross must be cloned alongside the decomp repo:
+# macOS (Apple Silicon / Intel) additionally:
+#   brew install cmake gcc sdl2 openal-soft
+#
+# PsyCross is pulled in as a git submodule at pc_port/PsyCross. If the
+# submodule isn't initialized, the script falls back to a sibling checkout:
 #   silenthill/
 #     silent-hill-decomp/
 #     PsyCross/
+
+set -e
 
 echo "=== Silent Hill PC Port Build ==="
 echo
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PSYCROSS_DIR="$SCRIPT_DIR/../../PsyCross"
+
+# PsyCross: prefer the git submodule, fall back to a sibling checkout.
+if [ -f "$SCRIPT_DIR/PsyCross/CMakeLists.txt" ]; then
+    PSYCROSS_DIR="$SCRIPT_DIR/PsyCross"
+elif [ -f "$SCRIPT_DIR/../../PsyCross/CMakeLists.txt" ]; then
+    PSYCROSS_DIR="$SCRIPT_DIR/../../PsyCross"
+else
+    echo "ERROR: PsyCross not found."
+    echo "Initialize the submodule:  git submodule update --init pc_port/PsyCross"
+    exit 1
+fi
 
 # Create build directory
 mkdir -p "$SCRIPT_DIR/build"
 cd "$SCRIPT_DIR/build"
 
-# Configure with CMake
-cmake .. \
-    -DCMAKE_BUILD_TYPE=Debug \
-    -DPSYCROSS_DIR="$PSYCROSS_DIR" \
-    -DSH_VERSION=USA \
+CMAKE_ARGS=(
+    -DCMAKE_BUILD_TYPE=Debug
+    -DPSYCROSS_DIR="$PSYCROSS_DIR"
+    -DSH_VERSION=USA
     -DSH_DEBUG=ON
+)
 
-if [ $? -ne 0 ]; then
-    echo
-    echo "CMake configuration failed!"
-    echo "Make sure SDL2 and OpenAL are installed:"
-    echo "  Ubuntu/Debian: sudo apt install libsdl2-dev libopenal-dev"
-    echo "  macOS: brew install sdl2 openal-soft"
-    exit 1
+if [ "$(uname -s)" = "Darwin" ]; then
+    # The PSX decomp C sources use GCC nested functions and rely on implicit
+    # declarations, which AppleClang rejects. Use Homebrew GCC for C; PsyCross
+    # and fmv C++ stay on the default (AppleClang) C++ compiler.
+    GCC_C="$(ls /opt/homebrew/bin/gcc-[0-9]* /usr/local/bin/gcc-[0-9]* 2>/dev/null | sort -V | tail -1)"
+    if [ -z "$GCC_C" ]; then
+        echo "ERROR: Homebrew GCC not found. Install it:  brew install gcc"
+        exit 1
+    fi
+    CMAKE_ARGS+=(-DCMAKE_C_COMPILER="$GCC_C")
+
+    # Point CMake at Homebrew's openal-soft instead of the system OpenAL
+    # framework.
+    OPENAL_PREFIX="$(brew --prefix openal-soft 2>/dev/null)"
+    if [ -n "$OPENAL_PREFIX" ]; then
+        CMAKE_ARGS+=(
+            -DOPENAL_LIBRARY="$OPENAL_PREFIX/lib/libopenal.dylib"
+            -DOPENAL_INCLUDE_DIR="$OPENAL_PREFIX/include"
+            -DCMAKE_EXE_LINKER_FLAGS="-L$OPENAL_PREFIX/lib"
+            -DCMAKE_SHARED_LINKER_FLAGS="-L$OPENAL_PREFIX/lib"
+        )
+    fi
 fi
+
+# Configure with CMake
+cmake .. "${CMAKE_ARGS[@]}"
 
 echo
 echo "CMake configured. Building..."
 echo
 
-cmake --build . -j$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+cmake --build . -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
 
-if [ $? -eq 0 ]; then
-    echo
-    echo "Build successful! Binary at: build/SilentHillPC"
-else
-    echo
-    echo "Build failed."
-    exit 1
-fi
+echo
+echo "Build successful! Binary at: build/SilentHillPC"

--- a/pc_port/include/psyq/libsnd.h
+++ b/pc_port/include/psyq/libsnd.h
@@ -59,11 +59,14 @@
 #endif
 
 /* VAB structures */
+/* long is 8 bytes on LP64 (macOS/Linux) but 4 bytes on PSX and Windows LLP64.
+ * These structs map directly to binary disc data (PSX 4-byte fields), so use
+ * fixed-width types to match the on-disc layout on all platforms. */
 typedef struct VabHdr {
-    long           form;
-    long           ver;
-    long           id;
-    unsigned long  fsize;
+    s32            form;
+    s32            ver;
+    s32            id;
+    u32            fsize;
     unsigned short reserved0;
     unsigned short ps;
     unsigned short ts;
@@ -72,7 +75,7 @@ typedef struct VabHdr {
     unsigned char  pan;
     unsigned char  attr1;
     unsigned char  attr2;
-    unsigned long  reserved1;
+    u32            reserved1;
 } VabHdr;
 
 typedef struct ProgAtr {
@@ -83,8 +86,8 @@ typedef struct ProgAtr {
     unsigned char mpan;
     char          reserved0;
     short         attr;
-    unsigned long reserved1;
-    unsigned long reserved2;
+    u32           reserved1;
+    u32           reserved2;
 } ProgAtr;
 
 typedef struct VagAtr {

--- a/pc_port/maps/CMakeLists.txt
+++ b/pc_port/maps/CMakeLists.txt
@@ -89,20 +89,28 @@ function(add_map_overlay MAP_NAME MAP_DEFINE)
     # comes first — both are byte-identical since they came from the same
     # static archive originally. Long-term cleanup: drop psycross_static
     # from this link and rely solely on the exe's import lib. */
-    target_link_options(${MAP_NAME} PRIVATE
-        "LINKER:--allow-multiple-definition"
-        # WINDOWS_EXPORT_ALL_SYMBOLS (set below) is *supposed* to emit a
-        # generated .def listing every global, but on this CMake/MinGW
-        # combo it silently does nothing for the map DLLs — the resulting
-        # build.ninja link rule has neither `--export-all-symbols` nor a
-        # generated def file, and DllLoader_GetSymbol fails with
-        # "GetProcAddress error 127" looking up g_MapOverlayHeader_<name>
-        # at runtime. Falling back to the global ld flag bypasses CMake's
-        # auto-export machinery and exports every TU-global in the DLL.
-        # Same flag the main exe uses; identical behavior to the old
-        # working state. */
-        "LINKER:--export-all-symbols"
-    )
+    if(MINGW)
+        # --export-all-symbols: WINDOWS_EXPORT_ALL_SYMBOLS silently no-ops on
+        # this CMake/MinGW combo, so force the ld flag directly.
+        target_link_options(${MAP_NAME} PRIVATE
+            "LINKER:--allow-multiple-definition"
+            "LINKER:--export-all-symbols"
+        )
+    elseif(APPLE)
+        # Symbols are exported by default from dylibs on macOS.
+        # Undefined symbols (resolved from the main exe at dlopen time) need
+        # this or ld64 errors on "undefined symbol" at link time.
+        target_link_options(${MAP_NAME} PRIVATE
+            "-Wl,-undefined,dynamic_lookup"
+        )
+    else()
+        # Linux: ENABLE_EXPORTS on the main exe adds -rdynamic; undefined
+        # symbols in .so files resolve from the exe automatically.
+        # psycross_static is in both exe and .so, so allow duplicates.
+        target_link_options(${MAP_NAME} PRIVATE
+            "LINKER:--allow-multiple-definition"
+        )
+    endif()
 
     # Export the g_MapOverlayHeader_<name> symbol from the DLL.
     # WINDOWS_EXPORT_ALL_SYMBOLS would auto-generate a .def file on

--- a/pc_port/src/ipd_reformat.c
+++ b/pc_port/src/ipd_reformat.c
@@ -61,8 +61,22 @@ static void ParseIpdModelBufferC(s_IpdModelInstance* dst, const u8* src)
     u32 modelIdx = rd32(&src[0]);
     dst->modelHdr = (s_ModelHeader*)(uintptr_t)modelIdx;
 
-    /* MATRIX at offset 4 (32 bytes): short m[3][3], short pad, long t[3] */
-    memcpy(&dst->mat, &src[4], sizeof(MATRIX));
+    /* PSX MATRIX is 32 bytes: short m[3][3] (18 bytes) + 2-byte pad + s32 t[3] (12 bytes).
+     * On macOS LP64, sizeof(MATRIX) = 48 (long t[] widens to 8 bytes each, 6-byte pad),
+     * so memcpy(sizeof(MATRIX)) would read 16 bytes past the binary data — parse
+     * field-by-field instead. PSX offsets from src[4]:
+     *   m[r][c] at (r*3+c)*2  (0..16)
+     *   t[0] at 20, t[1] at 24, t[2] at 28 */
+    {
+        int r, c;
+        const u8* msrc = &src[4];
+        for (r = 0; r < 3; r++)
+            for (c = 0; c < 3; c++)
+                dst->mat.m[r][c] = rds16(&msrc[(r * 3 + c) * 2]);
+        dst->mat.t[0] = rds32(&msrc[20]);
+        dst->mat.t[1] = rds32(&msrc[24]);
+        dst->mat.t[2] = rds32(&msrc[28]);
+    }
 }
 
 static void ParseIpdModelBuffer(s_IpdModelBuffer* dst, const u8* src, u8* base)

--- a/pc_port/src/main_pc.c
+++ b/pc_port/src/main_pc.c
@@ -434,6 +434,7 @@ int main(int argc, char* argv[])
      *   3 = both      — overlay + console window (same overlay content as 2) */
     {
         int show = g_PcConfig.showConsole;
+#ifdef _WIN32
         if (show == 1 || show == 3) {
             /* GUI-subsystem app: no console exists at launch, so create one for
              * external mode and point stdout/stderr at it. */
@@ -445,8 +446,6 @@ int main(int argc, char* argv[])
             setvbuf(stdout, NULL, _IONBF, 0);
             setvbuf(stderr, NULL, _IONBF, 0);
         } else {
-            /* No console in a GUI-subsystem app — just route stdout/stderr to
-             * the log file (or NUL) so stray printf doesn't hit an invalid handle. */
             if (g_PcConfig.enableDebugLog) {
                 freopen(SH_LogPath(), "a", stdout);
                 freopen(SH_LogPath(), "a", stderr);
@@ -457,6 +456,14 @@ int main(int argc, char* argv[])
                 freopen("NUL", "w", stderr);
             }
         }
+#else
+        if (show == 1 || show == 3) {
+            g_ShDebugEchoStdout = 1;
+        } else if (!g_PcConfig.enableDebugLog) {
+            freopen("/dev/null", "w", stdout);
+            freopen("/dev/null", "w", stderr);
+        }
+#endif
         /* Always capture log lines into the overlay ring buffer so the in-game
          * console can be toggled on at runtime (`~`) and immediately show recent
          * output, even when it booted disabled. Visibility is gated in

--- a/pc_port/src/map_overlay_loader.c
+++ b/pc_port/src/map_overlay_loader.c
@@ -11,9 +11,11 @@
 #include <string.h>
 
 #ifdef _WIN32
-#define DLL_EXT ".dll"
+#  define DLL_EXT ".dll"
+#elif defined(__APPLE__)
+#  define DLL_EXT ".dylib"
 #else
-#define DLL_EXT ".so"
+#  define DLL_EXT ".so"
 #endif
 
 /* Currently loaded overlay */

--- a/pc_port/src/pc_console_cmd.c
+++ b/pc_port/src/pc_console_cmd.c
@@ -16,6 +16,9 @@
  */
 #include "game.h"
 #include "bodyprog/bodyprog.h"
+#include "bodyprog/game_boot/game_boot.h"
+#include "bodyprog/events/player_pos_update.h"
+#include "bodyprog/item_screens.h"
 #include "bodyprog/items.h"
 #include "bodyprog/savegame.h"
 #include "bodyprog/screen/screen_fade.h"

--- a/pc_port/src/pc_crash_posix.c
+++ b/pc_port/src/pc_crash_posix.c
@@ -1,0 +1,5 @@
+/* pc_crash_posix.c — no-op crash filter stub for non-Windows platforms.
+ * The actual crash telemetry (pc_crash.c) is Windows-only (SEH). */
+#ifndef _WIN32
+void Sh_InstallCrashFilter(void) {}
+#endif

--- a/src/bodyprog/3d_audio.c
+++ b/src/bodyprog/3d_audio.c
@@ -143,6 +143,8 @@ s32 func_8005D9B8(VECTOR3* pos, q23_8 vol) // 0x8005D9B8
     return var_v0;
 }
 
+void func_8005DC3C(e_SfxId sfxId, const VECTOR3* pos, q23_8 vol, s32 soundType, s32 pitch);
+
 void func_8005DC1C(e_SfxId sfxId, const VECTOR3* pos, q23_8 vol, s32 soundType)
 {
     func_8005DC3C(sfxId, pos, vol, soundType, 0);

--- a/src/bodyprog/bodyprog_80089090.c
+++ b/src/bodyprog/bodyprog_80089090.c
@@ -15,6 +15,8 @@
 #include "sh_log.h"
 #endif
 extern u8 D_800AFD04;extern u8 D_800AFD05;extern bool (*D_800AFD08[])(s_SysWork_2514* arg0, s_func_8009ECCC* arg1, s_8002AC04* ptr, u32* arg3);
+void func_8008989C(s_SysWork_2514* arg0, u16 arg1, s32 (*arg2)(u16, s32));
+void func_8008992C(s_SysWork_2514* arg0, u16 arg1, s32 (*arg2)(u16, s32));
 
 // ========================================
 // VIBRATION HANDLING RELATED

--- a/src/maps/characters/alessa.c
+++ b/src/maps/characters/alessa.c
@@ -68,8 +68,8 @@ void Alessa_MovementUpdate(s_SubCharacter* alessa, GsCOORDINATE2* boneCoords)
     scaleRestoreShift = OVERFLOW_GUARD(moveDist);
     scaleReduceShift  = scaleRestoreShift >> 1;
 
-    offset.vx = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
-    offset.vz = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
+    offset.vx = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
+    offset.vz = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
     offset.vy = Q12_MULT_PRECISE(alessa->fallSpeed, g_DeltaTime);
 
     alessa->position.vx += offset.vx;

--- a/src/maps/characters/bloody_incubator.c
+++ b/src/maps/characters/bloody_incubator.c
@@ -39,8 +39,8 @@ void func_800D3740(s_SubCharacter* bloodyIncubator, GsCOORDINATE2* boneCoords) /
     scaleRestoreShift = OVERFLOW_GUARD(moveDist);
     scaleReduceShift  = scaleRestoreShift >> 1;
 
-    offset.vx = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
-    offset.vz = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
+    offset.vx = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
+    offset.vz = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
     offset.vy = Q12_MULT_PRECISE(bloodyIncubator->fallSpeed, g_DeltaTime);
 
     bloodyIncubator->position.vx += offset.vx;

--- a/src/maps/characters/bloody_lisa.c
+++ b/src/maps/characters/bloody_lisa.c
@@ -65,8 +65,8 @@ void BloodyLisa_MovementUpdate(s_SubCharacter* bloodyLisa, GsCOORDINATE2* boneCo
     scaleRestoreShift = OVERFLOW_GUARD(moveDist);
     scaleReduceShift  = scaleRestoreShift >> 1;
 
-    offset.vx = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
-    offset.vz = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
+    offset.vx = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
+    offset.vz = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
     offset.vy = Q12_MULT_PRECISE(bloodyLisa->fallSpeed, g_DeltaTime);
 
     bloodyLisa->position.vx += offset.vx;

--- a/src/maps/characters/cheryl.c
+++ b/src/maps/characters/cheryl.c
@@ -3,6 +3,9 @@
 #include "bodyprog/player.h"
 #include "maps/shared.h"
 #include "maps/characters/cheryl.h"
+#ifdef SH_PC_PORT
+#include "sh_log.h"
+#endif
 
 /** AI code for `Chara_Cheryl`
  *
@@ -88,8 +91,8 @@ void Cheryl_MovementUpdate(s_SubCharacter* cheryl, GsCOORDINATE2* coords) // 0x8
     scaleRestoreShift = OVERFLOW_GUARD(moveDist);
     scaleReduceShift  = scaleRestoreShift >> 1;
 
-    offset.vx = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
-    offset.vz = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
+    offset.vx = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
+    offset.vz = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
     offset.vy = Q12_MULT_PRECISE(cheryl->fallSpeed, g_DeltaTime);
 
     Collision_WallDetect(&sharedData_800E39BC_0_s00, &offset, cheryl);

--- a/src/maps/characters/cybil.c
+++ b/src/maps/characters/cybil.c
@@ -96,8 +96,8 @@ void Ai_Cybil_MovementUpdate(s_SubCharacter* chara, GsCOORDINATE2* coords)
     scaleRestoreShift = OVERFLOW_GUARD(moveDist);
     scaleReduceShift  = scaleRestoreShift >> 1;
 
-    offset.vx = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
-    offset.vz = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
+    offset.vx = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
+    offset.vz = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
     offset.vy = Q12_MULT_PRECISE(chara->fallSpeed, g_DeltaTime);
 
     chara->position.vx += offset.vx;

--- a/src/maps/characters/dahlia.c
+++ b/src/maps/characters/dahlia.c
@@ -78,8 +78,8 @@ void Dahlia_MovementUpdate(s_SubCharacter* dahlia, GsCOORDINATE2* boneCoords)
     scaleReduceShift  = scaleRestoreShift >> 1;
 
     // Compute movement offset.
-    offset.vx = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
-    offset.vz = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
+    offset.vx = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
+    offset.vz = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
     offset.vy = Q12_MULT_PRECISE(dahlia->fallSpeed, g_DeltaTime);
 
     Collision_WallDetect(&sharedData_800E39BC_0_s00, &offset, dahlia);

--- a/src/maps/characters/ghost_child_alessa.c
+++ b/src/maps/characters/ghost_child_alessa.c
@@ -59,8 +59,8 @@ void GhostChildAlessa_MovementUpdate(s_SubCharacter* ghostAlessa, GsCOORDINATE2*
     scaleRestoreShift = OVERFLOW_GUARD(moveDist);
     scaleReduceShift  = scaleRestoreShift >> 1;
 
-    offset.vx = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
-    offset.vz = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
+    offset.vx = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
+    offset.vz = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
     offset.vy = Q12_MULT_PRECISE(ghostAlessa->fallSpeed, g_DeltaTime);
 
     ghostAlessa->position.vx += offset.vx;

--- a/src/maps/characters/incubator.c
+++ b/src/maps/characters/incubator.c
@@ -39,8 +39,8 @@ void func_800D3C80(s_SubCharacter* incubator, GsCOORDINATE2* boneCoords)
     scaleRestoreShift = OVERFLOW_GUARD(moveDist);
     scaleReduceShift  = scaleRestoreShift >> 1;
 
-    offset.vx = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
-    offset.vz = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
+    offset.vx = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
+    offset.vz = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
     offset.vy = Q12_MULT_PRECISE(incubator->fallSpeed, g_DeltaTime);
 
     incubator->position.vx += offset.vx;

--- a/src/maps/characters/kaufmann.c
+++ b/src/maps/characters/kaufmann.c
@@ -71,8 +71,8 @@ void Kaufmann_MovementUpdate(s_SubCharacter* kaufmann, GsCOORDINATE2* boneCoords
     scaleRestoreShift = OVERFLOW_GUARD(moveDist);
     scaleReduceShift  = scaleRestoreShift >> 1;
 
-    offset.vx = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
-    offset.vz = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
+    offset.vx = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
+    offset.vz = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
     offset.vy = Q12_MULT_PRECISE(kaufmann->fallSpeed, g_DeltaTime);
 
     kaufmann->position.vx += offset.vx;

--- a/src/maps/characters/lisa.c
+++ b/src/maps/characters/lisa.c
@@ -73,8 +73,8 @@ void Lisa_MovementUpdate(s_SubCharacter* lisa, GsCOORDINATE2* boneCoords)
     scaleRestoreShift = OVERFLOW_GUARD(moveDist);
     scaleReduceShift  = scaleRestoreShift >> 1;
 
-    offset.vx = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
-    offset.vz = (u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift;
+    offset.vx = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Sin(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
+    offset.vz = (s32)((u32)Q12_MULT_PRECISE(moveDist >> scaleReduceShift, Math_Cos(headingAngle) >> scaleReduceShift) << scaleRestoreShift);
     offset.vy = Q12_MULT_PRECISE(lisa->fallSpeed, g_DeltaTime);
 
     lisa->position.vx += offset.vx;


### PR DESCRIPTION
Adds native macOS (Apple Silicon, arm64) build support. Note that this depends on a PR from PsyCross as well: https://github.com/SlickAmogus/PsyCross/pull/1

Once that is merged in, we can update the PsyCross submodule reference to point to the new tip.

   ## What's here (5 commits)

   - **`_WIN32` guard the console/`AllocConsole` setup** — the Windows-only
     console attach block compiles on POSIX otherwise. Adds a POSIX branch that
     routes stdout/stderr to `/dev/null` (or keeps stdout for the overlay).
   - **macOS map overlay build** — `map_overlay_loader.c` uses the
     platform-correct shared-object extension (`.dylib` on macOS, `.dll` on
     Windows); `maps/CMakeLists.txt` gates the GNU-ld-specific linker flags
     behind a non-Apple check so ld64 doesn't choke on them.
   - **fix LP64 `long`→8-byte type bugs** — the PSX code assumes `long` = 4
     bytes. On macOS LP64 (`long` = 8) this silently corrupted NPC positions
     and model matrices; Windows LLP64 (`long` = 4) was unaffected:
     - NPC movement (`cheryl`, `cybil`, `dahlia`, `lisa`, `alessa`, …):
       `offset.vx = (u32)Q12_MULT_PRECISE(...) << shift` zero-extended the
       u32 into `VECTOR3::vx` (long), turning negative sin/cos values into
       large positive offsets; NPCs drifted off the grid and fell through
       the floor. Wrap in `(s32)(...)` so the 32-bit pattern is sign-extended.
     - `ipd_reformat.c`: `memcpy(&dst->mat, &src[4], sizeof(MATRIX))` read
       48 bytes (long t[3] widens + pads on LP64) from a 32-byte PSX MATRIX.
       Parse `m[3][3]`/`t[3]` field-by-field at the known PSX offsets.
     - `libsnd.h`: `VabHdr`/`ProgAtr` used `long` members; switch to `s32`/`u32`
       so the structs match the PSX binary layout on LP64.
   - **adapt `build.sh` for macOS** — resolve PsyCross via the
     `pc_port/PsyCross` submodule (sibling checkout fallback); on Darwin use
     Homebrew GCC for C and point CMake at Homebrew's `openal-soft`. Also sets
     the executable bit on `build.sh`.
   - **GCC-15 / POSIX compile fixes** — GCC-15 promotes several long-standing
     implicit-declaration/style issues from warning to error. Add the missing
     forward declarations/includes, a no-op POSIX crash stub
     (`pc_crash_posix.c`), exclude the Windows-only `pc_crash.c` on non-Win,
     and on Apple quiet the decomp's noisy warnings back to the level the
     Windows toolchain tolerates.

   ## Build (macOS, Apple Silicon)

   ```bash
   brew install cmake gcc sdl2 openal-soft jpeg-turbo
   ./pc_port/build.sh
 ```

 build.sh uses Homebrew GCC for C — the decomp sources use GCC nested
 functions (e.g. Screen_BlackBorderDraw, Event_ItemTriggersClear) and
 statement-expression macros that AppleClang rejects with no flag to enable.
 C++ (PsyCross, fmv) stays on AppleClang. Verified: clean build + the binary
 boots and runs on macOS 26.5.1.

 Scope

 No game-logic / behavior changes — these are porting (type-size and
 platform) correctness fixes only. All PSX-match semantics are preserved.