### PR TITLE
Linux support

### DIFF
--- a/include/decomp/types.h
+++ b/include/decomp/types.h
@@ -43,9 +43,9 @@ typedef unsigned long long q52_12; // Q52.12 fixed-point.
 /** @brief Smaller `VECTOR` with padding removed. Used for fixed-point positions. */
 typedef struct _VECTOR3
 {
-    /* 0x0 */ long vx;
-    /* 0x4 */ long vy;
-    /* 0x8 */ long vz;
+    /* 0x0 */ s32 vx;
+    /* 0x4 */ s32 vy;
+    /* 0x8 */ s32 vz;
 } VECTOR3;
 
 /** @brief Smaller `SVECTOR` with padding removed. Used for fixed-point rotations. */

--- a/pc_port/CMakeLists.txt
+++ b/pc_port/CMakeLists.txt
@@ -4,6 +4,12 @@ project(SilentHillPC C CXX)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 
+# Build everything position-independent. On Linux the map overlays are .so
+# shared objects that link the static psycross_static archive; linking a
+# static (non-PIC) archive into a shared object fails, so force PIC globally.
+# Harmless on Windows/MinGW (PE code is already position-independent).
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # =============================================================================
 # Options
 # =============================================================================
@@ -310,6 +316,19 @@ else()
         -Wno-incompatible-pointer-types
         -Wno-discarded-qualifiers
         -Wno-builtin-declaration-mismatch
+    )
+    # GCC 14 promoted several long-standing C warnings to hard errors by
+    # default (implicit function/int declarations, int<->pointer conversions,
+    # missing parameter types). The WIP decomp deliberately relies on these
+    # being warnings (as they are on the MinGW GCC 13 the Windows build uses),
+    # so demote them back to warnings. C-only to avoid cc1plus noise on .cpp.
+    target_compile_options(SilentHillPC PRIVATE
+        $<$<COMPILE_LANGUAGE:C>:-Wno-error=implicit-function-declaration>
+        $<$<COMPILE_LANGUAGE:C>:-Wno-error=implicit-int>
+        $<$<COMPILE_LANGUAGE:C>:-Wno-error=int-conversion>
+        $<$<COMPILE_LANGUAGE:C>:-Wno-error=incompatible-pointer-types>
+        $<$<COMPILE_LANGUAGE:C>:-Wno-error=declaration-missing-parameter-type>
+        $<$<COMPILE_LANGUAGE:C>:-Wno-error=return-mismatch>
     )
 endif()
 

--- a/pc_port/build.sh
+++ b/pc_port/build.sh
@@ -22,7 +22,12 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="$SCRIPT_DIR/build"
-EXE="$BUILD_DIR/SilentHillPC.exe"
+# Executable name is platform-specific: SilentHillPC.exe on Windows/MSYS2,
+# plain SilentHillPC on Linux/macOS.
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) EXE="$BUILD_DIR/SilentHillPC.exe" ;;
+    *)                    EXE="$BUILD_DIR/SilentHillPC" ;;
+esac
 
 MODE="${1:-build}"
 
@@ -68,10 +73,10 @@ else
     cmake --build "$BUILD_DIR"
 fi
 
-[ -f "$EXE" ] || { echo "ERROR: SilentHillPC.exe was not produced." >&2; exit 1; }
+[ -f "$EXE" ] || { echo "ERROR: $(basename "$EXE") was not produced." >&2; exit 1; }
 echo "Build OK: $EXE"
 
 if [ "$MODE" = "run" ]; then
     echo "Launching..."
-    ( cd "$BUILD_DIR" && ./SilentHillPC.exe )
+    ( cd "$BUILD_DIR" && "$EXE" )
 fi

--- a/pc_port/include/psyq/libsnd.h
+++ b/pc_port/include/psyq/libsnd.h
@@ -59,11 +59,18 @@
 #endif
 
 /* VAB structures */
+/* NOTE: these structs are overlaid directly on the raw VAB data read from
+ * disc, so their layout MUST match the PSX's. PSX `long` is 32-bit; using the
+ * C `long` here is correct on Windows (LLP64, long==4) but WRONG on Linux/
+ * macOS (LP64, long==8), where it shifts every following field and inflates
+ * sizeof — fsize/ps were read at the wrong offset, yielding a garbage VAB
+ * size and an SPU-malloc failure that crashed VAB transfer. Use fixed-width
+ * 32-bit ints so the layout is correct on every target. */
 typedef struct VabHdr {
-    long           form;
-    long           ver;
-    long           id;
-    unsigned long  fsize;
+    int            form;
+    int            ver;
+    int            id;
+    unsigned int   fsize;
     unsigned short reserved0;
     unsigned short ps;
     unsigned short ts;
@@ -72,7 +79,7 @@ typedef struct VabHdr {
     unsigned char  pan;
     unsigned char  attr1;
     unsigned char  attr2;
-    unsigned long  reserved1;
+    unsigned int   reserved1;
 } VabHdr;
 
 typedef struct ProgAtr {
@@ -83,8 +90,8 @@ typedef struct ProgAtr {
     unsigned char mpan;
     char          reserved0;
     short         attr;
-    unsigned long reserved1;
-    unsigned long reserved2;
+    unsigned int  reserved1;
+    unsigned int  reserved2;
 } ProgAtr;
 
 typedef struct VagAtr {

--- a/pc_port/maps/CMakeLists.txt
+++ b/pc_port/maps/CMakeLists.txt
@@ -94,48 +94,78 @@ function(add_map_overlay MAP_NAME MAP_DEFINE)
             -Wno-unused-variable
             -Wno-unused-function
         )
+        # GCC 14 turned these long-standing C warnings into default errors;
+        # the WIP decomp expects them to be warnings (as on the MinGW GCC 13
+        # the Windows build uses). Demote back to warnings (C-only).
+        target_compile_options(${MAP_NAME} PRIVATE
+            $<$<COMPILE_LANGUAGE:C>:-Wno-error=implicit-function-declaration>
+            $<$<COMPILE_LANGUAGE:C>:-Wno-error=implicit-int>
+            $<$<COMPILE_LANGUAGE:C>:-Wno-error=int-conversion>
+            $<$<COMPILE_LANGUAGE:C>:-Wno-error=incompatible-pointer-types>
+            $<$<COMPILE_LANGUAGE:C>:-Wno-error=declaration-missing-parameter-type>
+            $<$<COMPILE_LANGUAGE:C>:-Wno-error=return-mismatch>
+        )
     endif()
 
-    # Link against the main executable's import library.
-    # Map DLL functions call back into game code (g_SysWork, etc.),
-    # so they need the exe's exported symbols to resolve at load time.
-    target_link_libraries(${MAP_NAME} PRIVATE SilentHillPC psycross_static)
+    if(WIN32)
+        # Link against the main executable's import library.
+        # Map DLL functions call back into game code (g_SysWork, etc.),
+        # so they need the exe's exported symbols to resolve at load time.
+        target_link_libraries(${MAP_NAME} PRIVATE SilentHillPC psycross_static)
 
-    # Map DLLs pull PsyCross symbols from BOTH the static psycross_static
-    # archive AND the exe's import lib (which re-exports PsyCross via the
-    # exe's --export-all-symbols). Pre-USE_PGXP=1 the linker silently
-    # picked one copy; turning PGXP on emitted PGXP_GetIndex (and pulled
-    # in extra libgpu/libapi symbols by reference) which triggered hard
-    # multiple-definition errors. Allow the linker to pick whichever copy
-    # comes first — both are byte-identical since they came from the same
-    # static archive originally. Long-term cleanup: drop psycross_static
-    # from this link and rely solely on the exe's import lib. */
-    target_link_options(${MAP_NAME} PRIVATE
-        "LINKER:--allow-multiple-definition"
-        # WINDOWS_EXPORT_ALL_SYMBOLS (set below) is *supposed* to emit a
-        # generated .def listing every global, but on this CMake/MinGW
-        # combo it silently does nothing for the map DLLs — the resulting
-        # build.ninja link rule has neither `--export-all-symbols` nor a
-        # generated def file, and DllLoader_GetSymbol fails with
-        # "GetProcAddress error 127" looking up g_MapOverlayHeader_<name>
-        # at runtime. Falling back to the global ld flag bypasses CMake's
-        # auto-export machinery and exports every TU-global in the DLL.
-        # Same flag the main exe uses; identical behavior to the old
-        # working state. */
-        "LINKER:--export-all-symbols"
-    )
+        # Map DLLs pull PsyCross symbols from BOTH the static psycross_static
+        # archive AND the exe's import lib (which re-exports PsyCross via the
+        # exe's --export-all-symbols). Pre-USE_PGXP=1 the linker silently
+        # picked one copy; turning PGXP on emitted PGXP_GetIndex (and pulled
+        # in extra libgpu/libapi symbols by reference) which triggered hard
+        # multiple-definition errors. Allow the linker to pick whichever copy
+        # comes first — both are byte-identical since they came from the same
+        # static archive originally. Long-term cleanup: drop psycross_static
+        # from this link and rely solely on the exe's import lib. */
+        target_link_options(${MAP_NAME} PRIVATE
+            "LINKER:--allow-multiple-definition"
+            # WINDOWS_EXPORT_ALL_SYMBOLS (set below) is *supposed* to emit a
+            # generated .def listing every global, but on this CMake/MinGW
+            # combo it silently does nothing for the map DLLs — the resulting
+            # build.ninja link rule has neither `--export-all-symbols` nor a
+            # generated def file, and DllLoader_GetSymbol fails with
+            # "GetProcAddress error 127" looking up g_MapOverlayHeader_<name>
+            # at runtime. Falling back to the global ld flag bypasses CMake's
+            # auto-export machinery and exports every TU-global in the DLL.
+            # Same flag the main exe uses; identical behavior to the old
+            # working state. */
+            "LINKER:--export-all-symbols"
+        )
+    else()
+        # Linux/macOS: a shared object cannot link against an executable, so
+        # we do NOT link SilentHillPC here. Game-code symbols (g_SysWork, the
+        # decompiled functions, etc.) are left undefined in the .so and
+        # resolved at dlopen() time from the main executable, which is built
+        # with ENABLE_EXPORTS (adds -rdynamic so its symbols populate the
+        # global dynamic symbol table). PsyCross is linked in statically
+        # (built PIC — see CMAKE_POSITION_INDEPENDENT_CODE in ../CMakeLists.txt).
+        # ELF shared objects export all global symbols by default, so
+        # g_MapOverlayHeader_<name> is visible to dlsym without extra flags.
+        target_link_libraries(${MAP_NAME} PRIVATE psycross_static)
+        # Build ordering only (the exe must exist to dlopen the map); there is
+        # no link-time dependency on the executable.
+        add_dependencies(${MAP_NAME} SilentHillPC)
+    endif()
 
-    # Export the g_MapOverlayHeader_<name> symbol from the DLL.
-    # WINDOWS_EXPORT_ALL_SYMBOLS would auto-generate a .def file on
-    # MinGW/MSVC in theory; in practice we use --export-all-symbols
-    # above (see comment) since the auto-def path silently no-ops here.
     set_target_properties(${MAP_NAME} PROPERTIES
         PREFIX ""                        # No "lib" prefix
-        OUTPUT_NAME "${MAP_NAME}"        # maps/map0_s01.dll
+        OUTPUT_NAME "${MAP_NAME}"        # maps/map0_s01.dll | maps/map0_s01.so
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/maps"
         LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/maps"
-        WINDOWS_EXPORT_ALL_SYMBOLS ON
     )
+    if(WIN32)
+        # Export the g_MapOverlayHeader_<name> symbol from the DLL.
+        # WINDOWS_EXPORT_ALL_SYMBOLS would auto-generate a .def file on
+        # MinGW/MSVC in theory; in practice we use --export-all-symbols
+        # above (see comment) since the auto-def path silently no-ops here.
+        # (No-op on ELF, where shared objects export globals by default.)
+        set_target_properties(${MAP_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    endif()
 
     message(STATUS "Map ${MAP_NAME}: DLL target created")
 endfunction()

--- a/pc_port/src/main_pc.c
+++ b/pc_port/src/main_pc.c
@@ -37,6 +37,13 @@
 #include <PsyX/PsyX_public.h>
 #include <PsyX/common/glad.h>
 
+/* Null device differs by platform: NUL on Windows, /dev/null on POSIX. */
+#ifdef _WIN32
+#define SH_NULL_DEVICE "NUL"
+#else
+#define SH_NULL_DEVICE "/dev/null"
+#endif
+
 /* Forward declarations from game code */
 extern void MainLoop(void);
 extern void Fs_QueueInitialize(void);
@@ -466,26 +473,30 @@ int main(int argc, char* argv[])
     {
         int show = g_PcConfig.showConsole;
         if (show == 1 || show == 3) {
+#ifdef _WIN32
             /* GUI-subsystem app: no console exists at launch, so create one for
              * external mode and point stdout/stderr at it. */
             extern __declspec(dllimport) int __stdcall AllocConsole(void);
             AllocConsole();
             freopen("CONOUT$", "w", stdout);
             freopen("CONOUT$", "w", stderr);
+#endif
+            /* On Linux/macOS the process is launched from a terminal, so
+             * stdout/stderr already point at a console — just echo to them. */
             g_ShDebugEchoStdout = 1;
             setvbuf(stdout, NULL, _IONBF, 0);
             setvbuf(stderr, NULL, _IONBF, 0);
         } else {
-            /* No console in a GUI-subsystem app — just route stdout/stderr to
-             * the log file (or NUL) so stray printf doesn't hit an invalid handle. */
+            /* No console — route stdout/stderr to the log file (or the null
+             * device) so stray printf doesn't hit an invalid handle. */
             if (g_PcConfig.enableDebugLog) {
                 freopen(SH_LogPath(), "a", stdout);
                 freopen(SH_LogPath(), "a", stderr);
                 setvbuf(stdout, NULL, _IONBF, 0);
                 setvbuf(stderr, NULL, _IONBF, 0);
             } else {
-                freopen("NUL", "w", stdout);
-                freopen("NUL", "w", stderr);
+                freopen(SH_NULL_DEVICE, "w", stdout);
+                freopen(SH_NULL_DEVICE, "w", stderr);
             }
         }
         /* Always capture log lines into the overlay ring buffer so the in-game

--- a/pc_port/src/pc_crash.c
+++ b/pc_port/src/pc_crash.c
@@ -16,9 +16,11 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
-#include <windows.h>
 
 extern FILE* g_ShDebugLog;
+
+#ifdef _WIN32
+#include <windows.h>
 
 static void Sh_LogFrame(int idx, DWORD64 pc)
 {
@@ -111,3 +113,15 @@ void Sh_InstallCrashFilter(void)
 {
     SetUnhandledExceptionFilter(Sh_CrashFilter);
 }
+
+#else /* !_WIN32 */
+
+/* POSIX no-op for now. The Windows path relies on SEH + RtlVirtualUnwind,
+ * which have no direct equivalent. A signal-based backtrace
+ * (sigaction + backtrace()/backtrace_symbols) can be added later; until
+ * then crashes fall through to the OS default (core dump / debugger). */
+void Sh_InstallCrashFilter(void)
+{
+}
+
+#endif /* _WIN32 */


### PR DESCRIPTION
These commits add Linux support. The main issues were the different size of `long` on Linux, a few cases of using things like `NUL` instead of `/dev/null`, and calling APIs to load DLLs that needed to be replaced. It works on my machine on Gentoo, and so it would be good to get confirmation that it still builds and runs on Windows with these changes applied.

The changes here require the changes that I have posted separately in your PsyCross repository:

https://github.com/SlickAmogus/PsyCross/pull/3