### PR TITLE
Match and stabilize per-pixel flashlight

### DIFF
--- a/pc_port/config.cfg
+++ b/pc_port/config.cfg
@@ -119,8 +119,8 @@ flashlight_shadows = 1
 #                            (head-mounted light: tighter + as bright)
 #   post_process_intensity : post-process effect mix (0..1, 1 = full effect)
 #   tonemap_intensity      : tone-map mix (0..1, 1 = full tone-map)
-flashlight_intensity = 2.10
-flashlight_size = 2.40
+flashlight_intensity = 0.89
+flashlight_size = 3.00
 flashlight_intensity_fps = 2.10
 flashlight_size_fps = 1.30
 post_process_intensity = 1.0

--- a/pc_port/config.cfg
+++ b/pc_port/config.cfg
@@ -119,7 +119,7 @@ flashlight_shadows = 1
 #                            (head-mounted light: tighter + as bright)
 #   post_process_intensity : post-process effect mix (0..1, 1 = full effect)
 #   tonemap_intensity      : tone-map mix (0..1, 1 = full tone-map)
-flashlight_intensity = 0.89
+flashlight_intensity = 1.20
 flashlight_size = 3.00
 flashlight_intensity_fps = 2.10
 flashlight_size_fps = 1.30

--- a/pc_port/src/pc_config.c
+++ b/pc_port/src/pc_config.c
@@ -650,3 +650,4 @@ void PcConfig_SaveMapName(const char* mapName)
         return;
     PcConfig_SaveKeyValue("map", mapName);
 }
+

--- a/pc_port/src/pc_config.c
+++ b/pc_port/src/pc_config.c
@@ -27,7 +27,7 @@ s_PcConfig g_PcConfig = {
     .tonemap        = 0, /* 0=off, 1=Reinhard, 2=ACES, 3=Filmic */
     .perPixelFlashlight = 0, /* 0=per-vertex (PSX), 1=per-pixel flashlight cone */
     .flashlightShadows  = 1, /* per-pixel flashlight casts real-time shadows (on by default; only visible when perPixelFlashlight is on) */
-    .flashlightIntensity  = 0.89f, /* per-pixel flashlight cone brightness scale, 0..3 */
+    .flashlightIntensity  = 1.20f, /* per-pixel flashlight cone brightness scale, 0..3 */
     .flashlightSize       = 3.00f, /* per-pixel flashlight cone coverage multiplier */
     .flashlightIntensityFps = 2.10f, /* FPS-mode brightness (head-mounted) */
     .flashlightSizeFps      = 1.30f, /* FPS-mode coverage (tighter than third-person) */

--- a/pc_port/src/pc_config.c
+++ b/pc_port/src/pc_config.c
@@ -27,8 +27,8 @@ s_PcConfig g_PcConfig = {
     .tonemap        = 0, /* 0=off, 1=Reinhard, 2=ACES, 3=Filmic */
     .perPixelFlashlight = 0, /* 0=per-vertex (PSX), 1=per-pixel flashlight cone */
     .flashlightShadows  = 1, /* per-pixel flashlight casts real-time shadows (on by default; only visible when perPixelFlashlight is on) */
-    .flashlightIntensity  = 2.10f, /* per-pixel flashlight cone brightness scale, 0..3 */
-    .flashlightSize       = 2.40f, /* per-pixel flashlight cone coverage multiplier */
+    .flashlightIntensity  = 0.89f, /* per-pixel flashlight cone brightness scale, 0..3 */
+    .flashlightSize       = 3.00f, /* per-pixel flashlight cone coverage multiplier */
     .flashlightIntensityFps = 2.10f, /* FPS-mode brightness (head-mounted) */
     .flashlightSizeFps      = 1.30f, /* FPS-mode coverage (tighter than third-person) */
     .postProcessIntensity = 1.0f, /* post-process effect mix, 0..1 */
@@ -650,4 +650,3 @@ void PcConfig_SaveMapName(const char* mapName)
         return;
     PcConfig_SaveKeyValue("map", mapName);
 }
-

--- a/src/bodyprog/gfx/bodyprog_80040B74.c
+++ b/src/bodyprog/gfx/bodyprog_80040B74.c
@@ -323,6 +323,9 @@ void func_800414E0(GsOT* arg0, VECTOR3* arg1, s32 arg2, q19_12 angle0, q19_12 an
     POLY_G3* poly_g3;
     POLY_G4* poly_g4;
     POLY_F4* poly_f4;
+#ifdef SH_PC_PORT
+    extern int g_PsyX_FlashlightActive;
+#endif
 
     if (arg1->vz < Q12(0.25f))
     {
@@ -384,7 +387,10 @@ void func_800414E0(GsOT* arg0, VECTOR3* arg1, s32 arg2, q19_12 angle0, q19_12 an
         *(s32*)&poly_g3->x1 = var_t0[j];
         *(s32*)&poly_g3->x2 = var_t0[j + 1];
 
-        addPrim(arg0->org, poly_g3);
+#ifdef SH_PC_PORT
+        if (!g_PsyX_FlashlightActive)
+#endif
+            addPrim(arg0->org, poly_g3);
 
         *(s32*)&poly_f4->x0 = var_t0[j + 51];
         *(s32*)&poly_f4->x1 = var_t0[j + 52];
@@ -410,7 +416,10 @@ void func_800414E0(GsOT* arg0, VECTOR3* arg1, s32 arg2, q19_12 angle0, q19_12 an
         }
     }
 
-    AddPrim(arg0->org, &D_800BFBF0[g_ActiveBufferIdx][sizeof(DR_TPAGE)]);
+#ifdef SH_PC_PORT
+    if (!g_PsyX_FlashlightActive)
+#endif
+        AddPrim(arg0->org, &D_800BFBF0[g_ActiveBufferIdx][sizeof(DR_TPAGE)]);
     AddPrim(&arg0->org[1], &D_800BFBF0[g_ActiveBufferIdx]);
 }
 

--- a/src/bodyprog/gfx/bodyprog_80055028.c
+++ b/src/bodyprog/gfx/bodyprog_80055028.c
@@ -171,6 +171,7 @@ void Gfx_2dEffectsDraw(void) // 0x800550D0
         extern float   g_PsyX_FlashlightPos[3];
         extern float   g_PsyX_FlashlightShadowPos[3];
         extern float   g_PsyX_FlashlightDir[3];
+        extern float   g_PsyX_FlashlightColor[3];
         extern VECTOR3 g_PcFlashlightShadowWorld;
 
         /* Gate on Harry's actual flashlight state (== what Game_FlashlightIsOn
@@ -231,6 +232,11 @@ void Gfx_2dEffectsDraw(void) // 0x800550D0
             g_PsyX_FlashlightDir[0] = (float)(s32)(((s64)GsWSMATRIX.m[0][0] * fdx + (s64)GsWSMATRIX.m[0][1] * fdy + (s64)GsWSMATRIX.m[0][2] * fdz) >> 12);
             g_PsyX_FlashlightDir[1] = (float)(s32)(((s64)GsWSMATRIX.m[1][0] * fdx + (s64)GsWSMATRIX.m[1][1] * fdy + (s64)GsWSMATRIX.m[1][2] * fdz) >> 12);
             g_PsyX_FlashlightDir[2] = (float)(s32)(((s64)GsWSMATRIX.m[2][0] * fdx + (s64)GsWSMATRIX.m[2][1] * fdy + (s64)GsWSMATRIX.m[2][2] * fdz) >> 12);
+
+            /* Match the room-specific RGB matrix used by the original flashlight. */
+            g_PsyX_FlashlightColor[0] = (float)g_WorldEnvWork.field_2C.m[0][0] / 4096.0f;
+            g_PsyX_FlashlightColor[1] = (float)g_WorldEnvWork.field_2C.m[1][0] / 4096.0f;
+            g_PsyX_FlashlightColor[2] = (float)g_WorldEnvWork.field_2C.m[2][0] / 4096.0f;
 
             g_PsyX_FlashlightActive = 1;
         }

--- a/src/bodyprog/gfx/bodyprog_80055028.c
+++ b/src/bodyprog/gfx/bodyprog_80055028.c
@@ -249,10 +249,8 @@ void Gfx_2dEffectsDraw(void) // 0x800550D0
 
     if (g_WorldEnvWork.field_2 != 0)
     {
-#ifdef SH_PC_PORT
         /* The per-pixel path still needs the original subtractive outer mask;
          * func_800414E0 suppresses only its additive center while the cone is active. */
-#endif
         func_80041074(ot, g_WorldEnvWork.field_54, &g_WorldEnvWork.field_58, &g_WorldEnvWork.field_60);
     }
 

--- a/src/bodyprog/gfx/bodyprog_80055028.c
+++ b/src/bodyprog/gfx/bodyprog_80055028.c
@@ -250,12 +250,8 @@ void Gfx_2dEffectsDraw(void) // 0x800550D0
     if (g_WorldEnvWork.field_2 != 0)
     {
 #ifdef SH_PC_PORT
-        /* Skip this PSX glow-polygon fan only when the per-pixel cone is actually
-         * lighting (flashlight on + feature on == g_PsyX_FlashlightActive); the
-         * cone replaces it and drawing both double-lights into blown-out
-         * highlights. With the cone inactive, draw the halo as the game intends. */
-        extern int g_PsyX_FlashlightActive;
-        if (!g_PsyX_FlashlightActive)
+        /* The per-pixel path still needs the original subtractive outer mask;
+         * func_800414E0 suppresses only its additive center while the cone is active. */
 #endif
         func_80041074(ot, g_WorldEnvWork.field_54, &g_WorldEnvWork.field_58, &g_WorldEnvWork.field_60);
     }


### PR DESCRIPTION
## Summary

Match the optional third-person per-pixel flashlight to Silent Hill's original beam shape, brightness, room color, contrast, and distance response while preserving the original flashlight path. This PR contains the game-side integration for the renderer work in SlickAmogus/PsyCross#7.

## Changes

- Set the calibrated third-person defaults to intensity `1.20` and size `3.00` in both the shipped configuration and compiled fallback defaults.
- Feed the per-pixel beam from the same room-specific Q12 RGB lighting matrix used by the original flashlight, including room transitions and runtime lighting changes.
- Continue drawing the original radial compositor in per-pixel mode, but suppress only its additive center while the cone is active.
- Preserve the original subtractive outer mask, restoring the intended bright-center/dark-surround contrast.
- Update the PsyCross submodule to the calibrated distance, cone-origin, and shadow-stability implementation.

## Result

- Original-matched flashlight size and shape.
- Calibrated brightness and room-specific color.
- Original-derived distance drop-off.
- Stable flashlight shadows.
- Original subtractive edge contrast.

## Safety and scope

- The behavior is limited to the existing per-pixel flashlight option.
- The legacy flashlight remains unchanged.
- Default lens-flare behavior is unchanged.
- FPS-mode flashlight values are unchanged.
- No experimental flare, model fixture, slider harness, or developer-launch tooling is included.

## Dependency

Merge SlickAmogus/PsyCross#7 first, then merge this PR.

## Validation

- Built `SilentHillPC` and all configured map DLLs.
- Calibrated and visually compared in Annie's Bar.
- Confirmed the final branch and submodule worktrees are clean.

**Target scene:** Annie's Bar (`map5_s02`).