### PR TITLE
fix: Prevents using Windows APIs on Unix enviroments which causes build fails

### DIFF
--- a/pc_port/src/tex_pack.c
+++ b/pc_port/src/tex_pack.c
@@ -6,7 +6,15 @@
 #include <math.h>
 #include <dirent.h>
 #include <sys/stat.h>
+
+#ifdef _WIN32
 #include <direct.h>
+#elif defined(__unix__)
+#include <strings.h>
+#define _strdup(s) strdup(s)
+#define _strnicmp(s1, s2, c) strncasecmp(s1, s2, c)
+#define _stricmp(s1, s2) strcasecmp(s1, s2)
+#endif
 
 #define XXH_INLINE_ALL
 #include "xxhash.h"


### PR DESCRIPTION
This PR prevents unix targets to use windows APIs, which causes to fail compilation