### PR TITLE
render: eliminate PGXP vertex jitter and add world depth

### DIFF
--- a/include/maps/map4/map4_s03.h
+++ b/include/maps/map4/map4_s03.h
@@ -17,6 +17,15 @@
 
 #include "maps/shared.h"
 
+#ifdef SH_PC_PORT
+#define COPY_GT4_PGXP_XY(poly, src, n) do {                         \
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)               \
+        Shadow_Copy(&(poly)->x##n, (src));                           \
+} while (0)
+#else
+#define COPY_GT4_PGXP_XY(poly, src, n) ((void)0)
+#endif
+
 #define COPY_GT4_DATA(poly, idx, ptr0, ptr1, ptr2, n) \
 {                                                     \
     u16* ptr4 = &(ptr0)[(idx)];                       \
@@ -25,6 +34,7 @@
                                                       \
     *(u16*)&(poly)->u##n = *ptr4;                     \
     *(s32*)&(poly)->x##n = *ptr5;                     \
+    COPY_GT4_PGXP_XY(poly, ptr5, n);                  \
     *(s32*)&(poly)->r##n = *ptr6;                     \
 }
 

--- a/pc_port/config.cfg
+++ b/pc_port/config.cfg
@@ -89,7 +89,7 @@ menu_pillarbox = 1
 # distant geometry doesn't jitter. WORK IN PROGRESS ??? turn on at your own
 # risk; expect rendering glitches until all prim emit sites are migrated
 # to populate the high-precision a_zw attribute.
-use_pgxp = 0
+use_pgxp = 1
 
 # Antialiasing (MSAA) on the 3D world. Smooths polygon edges; textures, dither
 # and 2D UI stay pixel-sharp. 0 = off, 2 / 4 / 8 = sample count (higher = smoother

--- a/pc_port/docs/Console_And_Debug_Reference.md
+++ b/pc_port/docs/Console_And_Debug_Reference.md
@@ -74,7 +74,7 @@ built-in quick lists.
 | Command | Description |
 |---|---|
 | `pgxp [0\|1]` | Perspective-correct textures (PGXP) on/off (WIP). **(saved)** Also F1. |
-| `pgxpedge <f>` | PGXP off-screen position clamp, psx-units (higher = less edge warp; default `8192`). |
+| `pgxpedge <f>` | Optional PGXP off-screen position clamp, PSX units (`0` = off, default). |
 | `pgxpdepth [0\|1]` | PGXP unquantized-depth W (distance-seam fix). |
 | `weld <f>` | PGXP seam-weld radius in px (`0` = off). |
 | `weldw <f>` | PGXP weld depth ratio. |

--- a/pc_port/include/inline_no_dmpsx.h
+++ b/pc_port/include/inline_no_dmpsx.h
@@ -46,6 +46,9 @@ extern void PGXP_StoreAddr(void* addr, int slot);
     MTC2(_p[0], 0); MTC2(_p[1], 1); \
     MTC2(_p[2], 2); MTC2(_p[3], 3); \
     MTC2(_p[4], 4); MTC2(_p[5], 5); \
+    PGXP_VectorLoad((const char*)(r0) + 0, 0); \
+    PGXP_VectorLoad((const char*)(r0) + 8, 1); \
+    PGXP_VectorLoad((const char*)(r0) + 16, 2); \
 } while(0)
 
 /* gte_ReadGeomScreen - read projection distance H (COP2 control reg 26)

--- a/pc_port/include/psyq/inline_c.h
+++ b/pc_port/include/psyq/inline_c.h
@@ -23,12 +23,18 @@
     MTC2(_p[0], 0); MTC2(_p[1], 1); \
     MTC2(_p[2], 2); MTC2(_p[3], 3); \
     MTC2(_p[4], 4); MTC2(_p[5], 5); \
+    PGXP_VectorLoad((const char*)(r0) + 0, 0); \
+    PGXP_VectorLoad((const char*)(r0) + 8, 1); \
+    PGXP_VectorLoad((const char*)(r0) + 16, 2); \
 } while(0)
 
 #undef gte_stsxy3c
 #define gte_stsxy3c( r0 ) do { \
     uint *_p = (uint*)((char*)(r0)); \
     _p[0] = MFC2(12); _p[1] = MFC2(13); _p[2] = MFC2(14); \
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight) { \
+        PGXP_StoreAddr(&_p[0], 0); PGXP_StoreAddr(&_p[1], 1); PGXP_StoreAddr(&_p[2], 2); \
+    } \
 } while(0)
 
 /* gte_stsxy3_g3: store SXY0/1/2 (GTE C12-14) into the X/Y slots of a
@@ -46,6 +52,9 @@
     *(uint*)(_b + 16) = MFC2(12); \
     *(uint*)(_b + 24) = MFC2(13); \
     *(uint*)(_b + 32) = MFC2(14); \
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight) { \
+        PGXP_StoreAddr(_b + 16, 0); PGXP_StoreAddr(_b + 24, 1); PGXP_StoreAddr(_b + 32, 2); \
+    } \
 } while(0)
 #else
 #define gte_stsxy3_g3( p ) do { \

--- a/pc_port/src/math_impl.c
+++ b/pc_port/src/math_impl.c
@@ -87,6 +87,15 @@ void Math_RotMatrixZxyNeg(SVECTOR* rot, MATRIX* mat)
     mat->m[2][0] = (short)((-sy*cz + cy*sx*sz) * 4096.0);
     mat->m[2][1] = (short)(( sy*sz + cy*sx*cz) * 4096.0);
     mat->m[2][2] = (short)(( cy*cx) * 4096.0);
+
+    {
+        const double exact[9] = {
+             cy*cz + sy*sx*sz, -cy*sz + sy*sx*cz,  sy*cx,
+             cx*sz,             cx*cz,            -sx,
+            -sy*cz + cy*sx*sz,  sy*sz + cy*sx*cz,  cy*cx
+        };
+        PGXP_MatrixRegister(mat, exact);
+    }
 }
 
 /*
@@ -123,6 +132,15 @@ void Math_RotMatrixXyz(SVECTOR* rot, MATRIX* mat)
     mat->m[2][0] = (short)((-cx*sy*cz + sx*sz) * 4096.0);
     mat->m[2][1] = (short)(( cx*sy*sz + sx*cz) * 4096.0);
     mat->m[2][2] = (short)(( cx*cy) * 4096.0);
+
+    {
+        const double exact[9] = {
+             cy*cz,             -cy*sz,             sy,
+             sx*sy*cz + cx*sz, -sx*sy*sz + cx*cz, -sx*cy,
+            -cx*sy*cz + sx*sz,  cx*sy*sz + sx*cz,  cx*cy
+        };
+        PGXP_MatrixRegister(mat, exact);
+    }
 }
 
 /*
@@ -150,6 +168,15 @@ void Math_RotMatrixZxy(SVECTOR* rot, MATRIX* mat)
     mat->m[2][0] = (short)(( sy*cx) * 4096.0);
     mat->m[2][1] = (short)((-sx) * 4096.0);
     mat->m[2][2] = (short)(( cy*cx) * 4096.0);
+
+    {
+        const double exact[9] = {
+             cy*cz + sy*sx*sz,  cx*sz, -sy*cz + cy*sx*sz,
+            -cy*sz + sy*sx*cz,  cx*cz,  sy*sz + cy*sx*cz,
+             sy*cx,             -sx,     cy*cx
+        };
+        PGXP_MatrixRegister(mat, exact);
+    }
 }
 
 /*
@@ -180,6 +207,15 @@ MATRIX* Math_RotMatrixZ(s32 angle, MATRIX* mat)
     mat->m[2][0] = 0;
     mat->m[2][1] = 0;
     mat->m[2][2] = 4096;
+
+    {
+        const double exact[9] = {
+             c, -s, 0.0,
+             s,  c, 0.0,
+             0.0, 0.0, 1.0
+        };
+        PGXP_MatrixRegister(mat, exact);
+    }
 
     return mat;
 }

--- a/pc_port/src/pc_console_cmd.c
+++ b/pc_port/src/pc_console_cmd.c
@@ -890,7 +890,7 @@ void Pc_ConsoleExec(const char* line)
     } else if (strcmp(cmd, "PGXPEDGE") == 0) {
         extern float g_PgxpEdgeMax;
         if (arg[0]) g_PgxpEdgeMax = (float)atof(arg);
-        cprintf("PGXP off-screen position clamp: %.0f psx-units (higher = less edge warp)", g_PgxpEdgeMax);
+        cprintf("PGXP off-screen position clamp: %.0f psx-units (0=off)", g_PgxpEdgeMax);
     } else if (strcmp(cmd, "PGXPDEPTH") == 0) {
         extern int g_PgxpUseUnquantizedDepth;
         if (arg[0] == '1') g_PgxpUseUnquantizedDepth = 1;

--- a/pc_port/src/pc_decals.c
+++ b/pc_port/src/pc_decals.c
@@ -67,6 +67,8 @@ typedef struct {
 
 static s_PcDecal s_decals[DECAL_MAX];
 extern s_WorldEnvWork g_WorldEnvWork;
+extern int g_PsxUsePgxp;
+extern int g_PsyX_UsePerPixelFlashlight;
 
 static int       s_decalCount = 0;
 static int       s_decalHead  = 0; /* FIFO write index (oldest overwritten) */
@@ -284,6 +286,7 @@ void Pc_DecalsDraw(GsOT* ot)
         const s_PcDecal* d = &s_decals[i];
         MATRIX           mat;
         SVECTOR          v;
+        s32              packedSxy[4];
         s16              sx[4];
         s16              sy[4];
         u16              sz[4];
@@ -304,7 +307,6 @@ void Pc_DecalsDraw(GsOT* ot)
             s32  st  = (k & 1) ? 1 : -1;
             s32  sb  = (k & 2) ? 1 : -1;
             s32  otz;
-            s32  sxy;
             long p;
             long flag;
 
@@ -312,16 +314,24 @@ void Pc_DecalsDraw(GsOT* ot)
             v.vy  = (s16)Q12_TO_Q8(st * d->axisU.vy + sb * d->axisV.vy);
             v.vz  = (s16)Q12_TO_Q8(st * d->axisU.vz + sb * d->axisV.vz);
             v.pad = 0;
+            PGXP_VectorRegisterQ12(&v,
+                                   st * d->axisU.vx + sb * d->axisV.vx,
+                                   st * d->axisU.vy + sb * d->axisV.vy,
+                                   st * d->axisU.vz + sb * d->axisV.vz);
 
-            otz = RotTransPers(&v, (int*)&sxy, &p, &flag);
+            /* Keep a distinct packed-word address per corner. RotTransPers
+             * attaches the precise SXY/view-space shadow to this address;
+             * reusing one loop-local word would leave only corner 3's
+             * provenance by the time the POLY_FT4 is assembled. */
+            otz = RotTransPers(&v, &packedSxy[k], &p, &flag);
             if (otz <= 8) /* behind/at the near plane */
             {
                 ok = 0;
                 break;
             }
 
-            sx[k] = (s16)(sxy & 0xFFFF);
-            sy[k] = (s16)((u32)sxy >> 16);
+            sx[k] = (s16)(packedSxy[k] & 0xFFFF);
+            sy[k] = (s16)((u32)packedSxy[k] >> 16);
             if (ABS(sx[k]) > 2048 || ABS(sy[k]) > 2048)
             {
                 ok = 0;
@@ -385,6 +395,13 @@ void Pc_DecalsDraw(GsOT* ot)
         poly->u3    = DECAL_UV_MAX;
         poly->v3    = DECAL_UV_MAX;
         setXY4(poly, sx[0], sy[0], sx[1], sy[1], sx[2], sy[2], sx[3], sy[3]);
+        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+        {
+            Shadow_Copy(&poly->x0, &packedSxy[0]);
+            Shadow_Copy(&poly->x1, &packedSxy[1]);
+            Shadow_Copy(&poly->x2, &packedSxy[2]);
+            Shadow_Copy(&poly->x3, &packedSxy[3]);
+        }
 
         PsyX_SetNextPrimSzExact(sz[0], sz[1], sz[2], sz[3]);
         addPrim(&ot->org[bucket], poly);

--- a/pc_port/src/stubs/libgs_stub.c
+++ b/pc_port/src/stubs/libgs_stub.c
@@ -220,13 +220,20 @@ void GsDrawOt(GsOT *ot)
 #ifdef SH_PC_PORT
         extern int g_currentOTBucketCount;
         extern void PsyX_ClearGteDepthTable(void);
+        extern void PsyX_ClearDrawBuffers(int clearDepth);
         g_currentOTBucketCount = 1 << ot->length;
         PsyX_ClearGteDepthTable();
 
-        glClearDepth(1.0f);
-        glClear(GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+        /* Preserve OT0 world depth while OT2/UI is composed later in the same
+         * frame. Depth is cleared once after GsSwapDispBuff resets the counter;
+         * stencil keeps its historical per-OT lifetime. Inventory has its own
+         * explicit depth clear in PsyX_ForceItemDepthBegin. */
+        PsyX_ClearDrawBuffers(gs_drawot_call_count == 0);
 #endif
         DrawOTag((u_long*)ot->tag);
+#ifdef SH_PC_PORT
+        gs_drawot_call_count++;
+#endif
     }
 }
 
@@ -378,6 +385,20 @@ extern unsigned short g_PsyX_RtpSz[4];
     if (g_PcItemPreciseDepth) { \
         PsyX_SetNextPrimSzExact(g_PsyX_RtpSz[0], g_PsyX_RtpSz[1], g_PsyX_RtpSz[2], g_PsyX_RtpSz[3]); \
     } } while (0)
+
+/* RotTransPers/3/4 writes each packed SXY word into the local `sxyN` variables
+ * through the instrumented gte_stsxy* macros, so those addresses own the
+ * precise PGXP/view-space shadow. Preserve that provenance when the TMD drawer
+ * copies the integer word into its final GPU packet field. The integer store is
+ * unchanged and the hook is completely skipped when both consumers are off. */
+extern int g_PsxUsePgxp;
+extern int g_PsyX_UsePerPixelFlashlight;
+extern int PsyX_PGXP_TriBackface(const void*, const void*, const void*, int);
+#define TMD_STORE_SXY(dst, src) do { \
+    *(u32*)&(dst) = *(const u32*)&(src); \
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight) \
+        Shadow_Copy(&(dst), &(src)); \
+} while (0)
  
 /* Flat-shaded triangle — lit + fog */
 void GsTMDfastF3LFG(void* op, VERT* vp, VERT* np, PACKET* pk, int n, int shift, GsOT* ot, unsigned long* scratch)
@@ -397,7 +418,7 @@ void GsTMDfastF3LFG(void* op, VERT* vp, VERT* np, PACKET* pk, int n, int shift, 
                       &sxy0, &sxy1, &sxy2, &p, &flg);
         nclip = NormalClip(sxy0, sxy1, sxy2);
         otz = p >> shift;
-        if (nclip <= 0) continue;
+        if (PsyX_PGXP_TriBackface(&sxy0, &sxy1, &sxy2, (int)nclip)) continue;
 
         col_in.r = prim->r0; col_in.g = prim->g0; col_in.b = prim->b0; col_in.cd = prim->code;
         NormalColorCol(&nrm[prim->n0], &col_in, &col_out);
@@ -408,7 +429,7 @@ void GsTMDfastF3LFG(void* op, VERT* vp, VERT* np, PACKET* pk, int n, int shift, 
         poly = (POLY_F3*)GsOUT_PACKET_P;
         setPolyF3(poly);
         setRGB0(poly, col_out.r, col_out.g, col_out.b);
-        *(int*)&poly->x0 = sxy0; *(int*)&poly->x1 = sxy1; *(int*)&poly->x2 = sxy2;
+        TMD_STORE_SXY(poly->x0, sxy0); TMD_STORE_SXY(poly->x1, sxy1); TMD_STORE_SXY(poly->x2, sxy2);
         ITEM_PRECISE_SZ(p); addPrim(&ot->org[otz], poly);
         GsOUT_PACKET_P = (u8*)poly + sizeof(POLY_F3);
     }
@@ -431,7 +452,7 @@ void GsTMDfastG3LFG(void* op, VERT* vp, VERT* np, PACKET* pk, int n, int shift, 
         RotTransPers3(&vtx[prim->v0], &vtx[prim->v1], &vtx[prim->v2],
                       &sxy0, &sxy1, &sxy2, &p, &flg);
         nclip = NormalClip(sxy0, sxy1, sxy2);
-        if (nclip <= 0) continue;
+        if (PsyX_PGXP_TriBackface(&sxy0, &sxy1, &sxy2, (int)nclip)) continue;
  
         col_in.r = prim->r0; col_in.g = prim->g0; col_in.b = prim->b0; col_in.cd = prim->code;
         NormalColorCol3(&nrm[prim->n0], &nrm[prim->n1], &nrm[prim->n2],
@@ -446,7 +467,7 @@ void GsTMDfastG3LFG(void* op, VERT* vp, VERT* np, PACKET* pk, int n, int shift, 
         setRGB0(poly, c0.r, c0.g, c0.b);
         setRGB1(poly, c1.r, c1.g, c1.b);
         setRGB2(poly, c2.r, c2.g, c2.b);
-        *(int*)&poly->x0 = sxy0; *(int*)&poly->x1 = sxy1; *(int*)&poly->x2 = sxy2;
+        TMD_STORE_SXY(poly->x0, sxy0); TMD_STORE_SXY(poly->x1, sxy1); TMD_STORE_SXY(poly->x2, sxy2);
         ITEM_PRECISE_SZ(p); addPrim(&ot->org[otz], poly);
         GsOUT_PACKET_P = (u8*)poly + sizeof(POLY_G3);
     }
@@ -470,7 +491,7 @@ void GsTMDfastF4LFG(void* op, VERT* vp, VERT* np, PACKET* pk, int n, int shift, 
                       &sxy0, &sxy1, &sxy2, &p, &flg);
         RotTransPers(&vtx[prim->v3], (int*)&sxy3, &p, &flg);
         nclip = NormalClip(sxy0, sxy1, sxy2);
-        if (nclip <= 0) continue;
+        if (PsyX_PGXP_TriBackface(&sxy0, &sxy1, &sxy2, (int)nclip)) continue;
  
         col_in.r = prim->r0; col_in.g = prim->g0; col_in.b = prim->b0; col_in.cd = prim->code;
         NormalColorCol(&nrm[prim->n0], &col_in, &col_out);
@@ -482,8 +503,8 @@ void GsTMDfastF4LFG(void* op, VERT* vp, VERT* np, PACKET* pk, int n, int shift, 
         poly = (POLY_F4*)GsOUT_PACKET_P;
         setPolyF4(poly);
         setRGB0(poly, col_out.r, col_out.g, col_out.b);
-        *(int*)&poly->x0 = sxy0; *(int*)&poly->x1 = sxy1;
-        *(int*)&poly->x2 = sxy2; *(int*)&poly->x3 = sxy3;
+        TMD_STORE_SXY(poly->x0, sxy0); TMD_STORE_SXY(poly->x1, sxy1);
+        TMD_STORE_SXY(poly->x2, sxy2); TMD_STORE_SXY(poly->x3, sxy3);
         ITEM_PRECISE_SZ(p); addPrim(&ot->org[otz], poly);
         GsOUT_PACKET_P = (u8*)poly + sizeof(POLY_F4);
     }
@@ -507,7 +528,7 @@ void GsTMDfastG4LFG(void* op, VERT* vp, VERT* np, PACKET* pk, int n, int shift, 
                       &sxy0, &sxy1, &sxy2, &p, &flg);
         RotTransPers(&vtx[prim->v3], (int*)&sxy3, &p, &flg);
         nclip = NormalClip(sxy0, sxy1, sxy2);
-        if (nclip <= 0) continue;
+        if (PsyX_PGXP_TriBackface(&sxy0, &sxy1, &sxy2, (int)nclip)) continue;
  
         col_in.r = prim->r0; col_in.g = prim->g0; col_in.b = prim->b0; col_in.cd = prim->code;
         NormalColorCol3(&nrm[prim->n0], &nrm[prim->n1], &nrm[prim->n2],
@@ -524,8 +545,8 @@ void GsTMDfastG4LFG(void* op, VERT* vp, VERT* np, PACKET* pk, int n, int shift, 
         setRGB2(poly, c2.r, c2.g, c2.b);
         /* v3 gets c2 color (PSX convention for quads) */
         setRGB3(poly, c2.r, c2.g, c2.b);
-        *(int*)&poly->x0 = sxy0; *(int*)&poly->x1 = sxy1;
-        *(int*)&poly->x2 = sxy2; *(int*)&poly->x3 = sxy3;
+        TMD_STORE_SXY(poly->x0, sxy0); TMD_STORE_SXY(poly->x1, sxy1);
+        TMD_STORE_SXY(poly->x2, sxy2); TMD_STORE_SXY(poly->x3, sxy3);
         ITEM_PRECISE_SZ(p); addPrim(&ot->org[otz], poly);
         GsOUT_PACKET_P = (u8*)poly + sizeof(POLY_G4);
     }
@@ -548,7 +569,7 @@ void GsTMDfastTF3LFG(void* op, VERT* vp, VERT* np, PACKET* pk, int n, int shift,
         RotTransPers3(&vtx[prim->v0], &vtx[prim->v1], &vtx[prim->v2],
                       &sxy0, &sxy1, &sxy2, &p, &flg);
         nclip = NormalClip(sxy0, sxy1, sxy2);
-        if (nclip <= 0) continue;
+        if (PsyX_PGXP_TriBackface(&sxy0, &sxy1, &sxy2, (int)nclip)) continue;
  
         /* Textured prims have no base color; use neutral 0x80 (half-bright
          * so NormalColorCol output stays in-range after lighting). */
@@ -565,7 +586,7 @@ void GsTMDfastTF3LFG(void* op, VERT* vp, VERT* np, PACKET* pk, int n, int shift,
         setUV3(poly, prim->tu0, prim->tv0, prim->tu1, prim->tv1, prim->tu2, prim->tv2);
         poly->tpage = prim->tpage;
         poly->clut  = prim->clut;
-        *(int*)&poly->x0 = sxy0; *(int*)&poly->x1 = sxy1; *(int*)&poly->x2 = sxy2;
+        TMD_STORE_SXY(poly->x0, sxy0); TMD_STORE_SXY(poly->x1, sxy1); TMD_STORE_SXY(poly->x2, sxy2);
         ITEM_PRECISE_SZ(p); addPrim(&ot->org[otz], poly);
         GsOUT_PACKET_P = (u8*)poly + sizeof(POLY_FT3);
     }
@@ -588,7 +609,7 @@ void GsTMDfastTG3LFG(void* op, VERT* vp, VERT* np, PACKET* pk, int n, int shift,
         RotTransPers3(&vtx[prim->v0], &vtx[prim->v1], &vtx[prim->v2],
                       &sxy0, &sxy1, &sxy2, &p, &flg);
         nclip = NormalClip(sxy0, sxy1, sxy2);
-        if (nclip <= 0) continue;
+        if (PsyX_PGXP_TriBackface(&sxy0, &sxy1, &sxy2, (int)nclip)) continue;
  
         col_in.r = 0x80; col_in.g = 0x80; col_in.b = 0x80; col_in.cd = prim->cd;
         NormalColorCol3(&nrm[prim->n0], &nrm[prim->n1], &nrm[prim->n2],
@@ -606,7 +627,7 @@ void GsTMDfastTG3LFG(void* op, VERT* vp, VERT* np, PACKET* pk, int n, int shift,
         setUV3(poly, prim->tu0, prim->tv0, prim->tu1, prim->tv1, prim->tu2, prim->tv2);
         poly->tpage = prim->tpage;
         poly->clut  = prim->clut;
-        *(int*)&poly->x0 = sxy0; *(int*)&poly->x1 = sxy1; *(int*)&poly->x2 = sxy2;
+        TMD_STORE_SXY(poly->x0, sxy0); TMD_STORE_SXY(poly->x1, sxy1); TMD_STORE_SXY(poly->x2, sxy2);
         ITEM_PRECISE_SZ(p); addPrim(&ot->org[otz], poly);
         GsOUT_PACKET_P = (u8*)poly + sizeof(POLY_GT3);
     }
@@ -631,7 +652,7 @@ void GsTMDfastTF4LFG(void* op, VERT* vp, VERT* np, PACKET* pk, int n, int shift,
                       &sxy0, &sxy1, &sxy2, &p, &flg);
         RotTransPers(&vtx[prim->v3], (int*)&sxy3, &p, &flg);
         nclip = NormalClip(sxy0, sxy1, sxy2);
-        if (nclip <= 0) continue;
+        if (PsyX_PGXP_TriBackface(&sxy0, &sxy1, &sxy2, (int)nclip)) continue;
 
         col_in.r = 0x80; col_in.g = 0x80; col_in.b = 0x80; col_in.cd = prim->cd;
         NormalColorCol(&nrm[prim->n0], &col_in, &col_out);
@@ -647,8 +668,8 @@ void GsTMDfastTF4LFG(void* op, VERT* vp, VERT* np, PACKET* pk, int n, int shift,
                      prim->tu2, prim->tv2, prim->tu3, prim->tv3);
         poly->tpage = prim->tpage;
         poly->clut  = prim->clut;
-        *(int*)&poly->x0 = sxy0; *(int*)&poly->x1 = sxy1;
-        *(int*)&poly->x2 = sxy2; *(int*)&poly->x3 = sxy3;
+        TMD_STORE_SXY(poly->x0, sxy0); TMD_STORE_SXY(poly->x1, sxy1);
+        TMD_STORE_SXY(poly->x2, sxy2); TMD_STORE_SXY(poly->x3, sxy3);
         ITEM_PRECISE_SZ(p); addPrim(&ot->org[otz], poly);
         GsOUT_PACKET_P = (u8*)poly + sizeof(POLY_FT4);
     }
@@ -672,7 +693,7 @@ void GsTMDfastTG4LFG(void* op, VERT* vp, VERT* np, PACKET* pk, int n, int shift,
                       &sxy0, &sxy1, &sxy2, &p, &flg);
         RotTransPers(&vtx[prim->v3], (int*)&sxy3, &p, &flg);
         nclip = NormalClip(sxy0, sxy1, sxy2);
-        if (nclip <= 0) continue;
+        if (PsyX_PGXP_TriBackface(&sxy0, &sxy1, &sxy2, (int)nclip)) continue;
  
         col_in.r = 0x80; col_in.g = 0x80; col_in.b = 0x80; col_in.cd = prim->cd;
         NormalColorCol3(&nrm[prim->n0], &nrm[prim->n1], &nrm[prim->n2],
@@ -692,8 +713,8 @@ void GsTMDfastTG4LFG(void* op, VERT* vp, VERT* np, PACKET* pk, int n, int shift,
                      prim->tu2, prim->tv2, prim->tu3, prim->tv3);
         poly->tpage = prim->tpage;
         poly->clut  = prim->clut;
-        *(int*)&poly->x0 = sxy0; *(int*)&poly->x1 = sxy1;
-        *(int*)&poly->x2 = sxy2; *(int*)&poly->x3 = sxy3;
+        TMD_STORE_SXY(poly->x0, sxy0); TMD_STORE_SXY(poly->x1, sxy1);
+        TMD_STORE_SXY(poly->x2, sxy2); TMD_STORE_SXY(poly->x3, sxy3);
         ITEM_PRECISE_SZ(p); addPrim(&ot->org[otz], poly);
         GsOUT_PACKET_P = (u8*)poly + sizeof(POLY_GT4);
     }
@@ -714,7 +735,7 @@ void GsTMDfastNF3(void* op, VERT* vp, PACKET* pk, int n, int shift, GsOT* ot, un
         RotTransPers3(&vtx[prim->v0], &vtx[prim->v1], &vtx[prim->v2],
                       &sxy0, &sxy1, &sxy2, &p, &flg);
         nclip = NormalClip(sxy0, sxy1, sxy2);
-        if (nclip <= 0) continue;
+        if (PsyX_PGXP_TriBackface(&sxy0, &sxy1, &sxy2, (int)nclip)) continue;
  
         otz = p >> shift;
         if (otz <= 0) continue;
@@ -723,7 +744,7 @@ void GsTMDfastNF3(void* op, VERT* vp, PACKET* pk, int n, int shift, GsOT* ot, un
         poly = (POLY_F3*)GsOUT_PACKET_P;
         setPolyF3(poly);
         setRGB0(poly, ITEMDIM(prim->r0), ITEMDIM(prim->g0), ITEMDIM(prim->b0));
-        *(int*)&poly->x0 = sxy0; *(int*)&poly->x1 = sxy1; *(int*)&poly->x2 = sxy2;
+        TMD_STORE_SXY(poly->x0, sxy0); TMD_STORE_SXY(poly->x1, sxy1); TMD_STORE_SXY(poly->x2, sxy2);
         ITEM_PRECISE_SZ(p); addPrim(&ot->org[otz], poly);
         GsOUT_PACKET_P = (u8*)poly + sizeof(POLY_F3);
     }
@@ -757,7 +778,7 @@ void GsTMDfastNG3(void* op, VERT* vp, PACKET* pk, int n, int shift, GsOT* ot, un
             RotTransPers3(&vtx[gp->v0], &vtx[gp->v1], &vtx[gp->v2],
                           &sxy0, &sxy1, &sxy2, &p, &flg);
             nclip = NormalClip(sxy0, sxy1, sxy2);
-            if (nclip <= 0) continue;
+            if (PsyX_PGXP_TriBackface(&sxy0, &sxy1, &sxy2, (int)nclip)) continue;
 
             otz = p >> shift;
             if (otz <= 0) continue;
@@ -766,7 +787,7 @@ void GsTMDfastNG3(void* op, VERT* vp, PACKET* pk, int n, int shift, GsOT* ot, un
             poly = (POLY_F3*)GsOUT_PACKET_P;
             setPolyF3(poly);
             setRGB0(poly, ITEMDIM(gp->r0), ITEMDIM(gp->g0), ITEMDIM(gp->b0));
-            *(int*)&poly->x0 = sxy0; *(int*)&poly->x1 = sxy1; *(int*)&poly->x2 = sxy2;
+            TMD_STORE_SXY(poly->x0, sxy0); TMD_STORE_SXY(poly->x1, sxy1); TMD_STORE_SXY(poly->x2, sxy2);
             ITEM_PRECISE_SZ(p); addPrim(&ot->org[otz], poly);
             GsOUT_PACKET_P = (u8*)poly + sizeof(POLY_F3);
         }
@@ -780,7 +801,7 @@ void GsTMDfastNG3(void* op, VERT* vp, PACKET* pk, int n, int shift, GsOT* ot, un
         RotTransPers3(&vtx[prim->v0], &vtx[prim->v1], &vtx[prim->v2],
                       &sxy0, &sxy1, &sxy2, &p, &flg);
         nclip = NormalClip(sxy0, sxy1, sxy2);
-        if (nclip <= 0) continue;
+        if (PsyX_PGXP_TriBackface(&sxy0, &sxy1, &sxy2, (int)nclip)) continue;
  
         otz = p >> shift;
         if (otz <= 0) continue;
@@ -791,7 +812,7 @@ void GsTMDfastNG3(void* op, VERT* vp, PACKET* pk, int n, int shift, GsOT* ot, un
         setRGB0(poly, ITEMDIM(prim->r0), ITEMDIM(prim->g0), ITEMDIM(prim->b0));
         setRGB1(poly, ITEMDIM(prim->r1), ITEMDIM(prim->g1), ITEMDIM(prim->b1));
         setRGB2(poly, ITEMDIM(prim->r2), ITEMDIM(prim->g2), ITEMDIM(prim->b2));
-        *(int*)&poly->x0 = sxy0; *(int*)&poly->x1 = sxy1; *(int*)&poly->x2 = sxy2;
+        TMD_STORE_SXY(poly->x0, sxy0); TMD_STORE_SXY(poly->x1, sxy1); TMD_STORE_SXY(poly->x2, sxy2);
         ITEM_PRECISE_SZ(p); addPrim(&ot->org[otz], poly);
         GsOUT_PACKET_P = (u8*)poly + sizeof(POLY_G3);
     }
@@ -813,7 +834,7 @@ void GsTMDfastNF4(void* op, VERT* vp, PACKET* pk, int n, int shift, GsOT* ot, un
                       &sxy0, &sxy1, &sxy2, &p, &flg);
         RotTransPers(&vtx[prim->v3], (int*)&sxy3, &p, &flg);
         nclip = NormalClip(sxy0, sxy1, sxy2);
-        if (nclip <= 0) continue;
+        if (PsyX_PGXP_TriBackface(&sxy0, &sxy1, &sxy2, (int)nclip)) continue;
  
         otz = p >> shift;
         if (otz <= 0) continue;
@@ -822,8 +843,8 @@ void GsTMDfastNF4(void* op, VERT* vp, PACKET* pk, int n, int shift, GsOT* ot, un
         poly = (POLY_F4*)GsOUT_PACKET_P;
         setPolyF4(poly);
         setRGB0(poly, ITEMDIM(prim->r0), ITEMDIM(prim->g0), ITEMDIM(prim->b0));
-        *(int*)&poly->x0 = sxy0; *(int*)&poly->x1 = sxy1;
-        *(int*)&poly->x2 = sxy2; *(int*)&poly->x3 = sxy3;
+        TMD_STORE_SXY(poly->x0, sxy0); TMD_STORE_SXY(poly->x1, sxy1);
+        TMD_STORE_SXY(poly->x2, sxy2); TMD_STORE_SXY(poly->x3, sxy3);
         ITEM_PRECISE_SZ(p); addPrim(&ot->org[otz], poly);
         GsOUT_PACKET_P = (u8*)poly + sizeof(POLY_F4);
     }
@@ -845,7 +866,7 @@ void GsTMDfastNG4(void* op, VERT* vp, PACKET* pk, int n, int shift, GsOT* ot, un
                       &sxy0, &sxy1, &sxy2, &p, &flg);
         RotTransPers(&vtx[prim->v3], (int*)&sxy3, &p, &flg);
         nclip = NormalClip(sxy0, sxy1, sxy2);
-        if (nclip <= 0) continue;
+        if (PsyX_PGXP_TriBackface(&sxy0, &sxy1, &sxy2, (int)nclip)) continue;
  
         otz = p >> shift;
         if (otz <= 0) continue;
@@ -857,8 +878,8 @@ void GsTMDfastNG4(void* op, VERT* vp, PACKET* pk, int n, int shift, GsOT* ot, un
         setRGB1(poly, ITEMDIM(prim->r1), ITEMDIM(prim->g1), ITEMDIM(prim->b1));
         setRGB2(poly, ITEMDIM(prim->r2), ITEMDIM(prim->g2), ITEMDIM(prim->b2));
         setRGB3(poly, ITEMDIM(prim->r3), ITEMDIM(prim->g3), ITEMDIM(prim->b3));
-        *(int*)&poly->x0 = sxy0; *(int*)&poly->x1 = sxy1;
-        *(int*)&poly->x2 = sxy2; *(int*)&poly->x3 = sxy3;
+        TMD_STORE_SXY(poly->x0, sxy0); TMD_STORE_SXY(poly->x1, sxy1);
+        TMD_STORE_SXY(poly->x2, sxy2); TMD_STORE_SXY(poly->x3, sxy3);
         ITEM_PRECISE_SZ(p); addPrim(&ot->org[otz], poly);
         GsOUT_PACKET_P = (u8*)poly + sizeof(POLY_G4);
     }
@@ -882,7 +903,7 @@ void GsTMDfastNTF3(void* op, VERT* vp, PACKET* pk, int n, int shift, GsOT* ot, u
         /* FCE (flag bit 1): double-sided — skip back-face cull */
         if (!(prim->dummy & 2)) {
             nclip = NormalClip(sxy0, sxy1, sxy2);
-            if (nclip <= 0) continue;
+            if (PsyX_PGXP_TriBackface(&sxy0, &sxy1, &sxy2, (int)nclip)) continue;
         }
 
         otz = p >> shift;
@@ -895,7 +916,7 @@ void GsTMDfastNTF3(void* op, VERT* vp, PACKET* pk, int n, int shift, GsOT* ot, u
         setUV3(poly, prim->tu0, prim->tv0, prim->tu1, prim->tv1, prim->tu2, prim->tv2);
         poly->tpage = prim->tpage;
         poly->clut  = prim->clut;
-        *(int*)&poly->x0 = sxy0; *(int*)&poly->x1 = sxy1; *(int*)&poly->x2 = sxy2;
+        TMD_STORE_SXY(poly->x0, sxy0); TMD_STORE_SXY(poly->x1, sxy1); TMD_STORE_SXY(poly->x2, sxy2);
         ITEM_PRECISE_SZ(p); addPrim(&ot->org[otz], poly);
         GsOUT_PACKET_P = (u8*)poly + sizeof(POLY_FT3);
     }
@@ -969,7 +990,7 @@ void GsTMDfastNTG3(void* op, VERT* vp, PACKET* pk, int n, int shift, GsOT* ot, u
                       &sxy0, &sxy1, &sxy2, &p, &flg);
         if (!(prim->flag & 2)) {
             nclip = NormalClip(sxy0, sxy1, sxy2);
-            if (nclip <= 0) continue;
+            if (PsyX_PGXP_TriBackface(&sxy0, &sxy1, &sxy2, (int)nclip)) continue;
         }
 
         otz = p >> shift;
@@ -986,7 +1007,7 @@ void GsTMDfastNTG3(void* op, VERT* vp, PACKET* pk, int n, int shift, GsOT* ot, u
         setUV3(poly, prim->tu0, prim->tv0, prim->tu1, prim->tv1, prim->tu2, prim->tv2);
         poly->tpage = prim->tpage;
         poly->clut  = prim->clut;
-        *(int*)&poly->x0 = sxy0; *(int*)&poly->x1 = sxy1; *(int*)&poly->x2 = sxy2;
+        TMD_STORE_SXY(poly->x0, sxy0); TMD_STORE_SXY(poly->x1, sxy1); TMD_STORE_SXY(poly->x2, sxy2);
         ITEM_PRECISE_SZ(p); addPrim(&ot->org[otz], poly);
         GsOUT_PACKET_P = (u8*)poly + sizeof(POLY_GT3);
     }
@@ -1008,7 +1029,7 @@ void GsTMDfastNTF4(void* op, VERT* vp, PACKET* pk, int n, int shift, GsOT* ot, u
                       &sxy0, &sxy1, &sxy2, &sxy3, &p, &flg);
         if (!(prim->dummy & 2)) {
             nclip = NormalClip(sxy0, sxy1, sxy2);
-            if (nclip <= 0) continue;
+            if (PsyX_PGXP_TriBackface(&sxy0, &sxy1, &sxy2, (int)nclip)) continue;
         }
 
         otz = p >> shift;
@@ -1022,8 +1043,8 @@ void GsTMDfastNTF4(void* op, VERT* vp, PACKET* pk, int n, int shift, GsOT* ot, u
                      prim->tu2, prim->tv2, prim->tu3, prim->tv3);
         poly->tpage = prim->tpage;
         poly->clut  = prim->clut;
-        *(int*)&poly->x0 = sxy0; *(int*)&poly->x1 = sxy1;
-        *(int*)&poly->x2 = sxy2; *(int*)&poly->x3 = sxy3;
+        TMD_STORE_SXY(poly->x0, sxy0); TMD_STORE_SXY(poly->x1, sxy1);
+        TMD_STORE_SXY(poly->x2, sxy2); TMD_STORE_SXY(poly->x3, sxy3);
         ITEM_PRECISE_SZ(p); addPrim(&ot->org[otz], poly);
         GsOUT_PACKET_P = (u8*)poly + sizeof(POLY_FT4);
     }
@@ -1045,7 +1066,7 @@ void GsTMDfastNTG4(void* op, VERT* vp, PACKET* pk, int n, int shift, GsOT* ot, u
                       &sxy0, &sxy1, &sxy2, &sxy3, &p, &flg);
         if (!(prim->dummy & 2)) {
             nclip = NormalClip(sxy0, sxy1, sxy2);
-            if (nclip <= 0) continue;
+            if (PsyX_PGXP_TriBackface(&sxy0, &sxy1, &sxy2, (int)nclip)) continue;
         }
 
         otz = p >> shift;
@@ -1063,8 +1084,8 @@ void GsTMDfastNTG4(void* op, VERT* vp, PACKET* pk, int n, int shift, GsOT* ot, u
                      prim->tu2, prim->tv2, prim->tu3, prim->tv3);
         poly->tpage = prim->tpage;
         poly->clut  = prim->clut;
-        *(int*)&poly->x0 = sxy0; *(int*)&poly->x1 = sxy1;
-        *(int*)&poly->x2 = sxy2; *(int*)&poly->x3 = sxy3;
+        TMD_STORE_SXY(poly->x0, sxy0); TMD_STORE_SXY(poly->x1, sxy1);
+        TMD_STORE_SXY(poly->x2, sxy2); TMD_STORE_SXY(poly->x3, sxy3);
         ITEM_PRECISE_SZ(p); addPrim(&ot->org[otz], poly);
         GsOUT_PACKET_P = (u8*)poly + sizeof(POLY_GT4);
     }
@@ -1185,9 +1206,21 @@ void GsDefDispBuff2(unsigned short x0, unsigned short y0, unsigned short x1, uns
 MATRIX* TransposeMatrix(MATRIX *m0, MATRIX *m1)
 {
     MATRIX t = *m0;
+    double exact[9];
+    int have_exact = PGXP_MatrixLookup(m0, exact);
     m1->m[0][0] = t.m[0][0]; m1->m[0][1] = t.m[1][0]; m1->m[0][2] = t.m[2][0];
     m1->m[1][0] = t.m[0][1]; m1->m[1][1] = t.m[1][1]; m1->m[1][2] = t.m[2][1];
     m1->m[2][0] = t.m[0][2]; m1->m[2][1] = t.m[1][2]; m1->m[2][2] = t.m[2][2];
+    if (have_exact) {
+        double transposed[9] = {
+            exact[0], exact[3], exact[6],
+            exact[1], exact[4], exact[7],
+            exact[2], exact[5], exact[8]
+        };
+        PGXP_MatrixRegister(m1, transposed);
+    } else {
+        PGXP_MatrixInvalidate(m1);
+    }
     return m1;
 }
 

--- a/src/bodyprog/bodyprog_8005E0DC.c
+++ b/src/bodyprog/bodyprog_8005E0DC.c
@@ -1118,6 +1118,12 @@ bool func_80060044(POLY_FT4** poly, s32 idx) // 0x80060044
                            Q12_TO_Q8(g_MapOverlayHdr.unkTable1_4C[idx].field_0.vx_0) - (u16)ptr->field_0.field_0.vx,
                            Q12_TO_Q8(g_MapOverlayHdr.unkTable1_4C[idx].vy_8) - ptr->field_0.field_0.vy,
                            Q12_TO_Q8(g_MapOverlayHdr.unkTable1_4C[idx].field_4.vz_4) - ptr->field_0.field_0.vz);
+#ifdef SH_PC_PORT
+    PGXP_VectorRegisterQ12(&ptr->field_138,
+                           g_MapOverlayHdr.unkTable1_4C[idx].field_0.vx_0 - Q8_TO_Q12((s16)ptr->field_0.field_0.vx),
+                           g_MapOverlayHdr.unkTable1_4C[idx].vy_8 - Q8_TO_Q12(ptr->field_0.field_0.vy),
+                           g_MapOverlayHdr.unkTable1_4C[idx].field_4.vz_4 - Q8_TO_Q12(ptr->field_0.field_0.vz));
+#endif
 
     gte_ldv0(&ptr->field_138);
     gte_rtps();
@@ -1175,6 +1181,13 @@ bool func_80060044(POLY_FT4** poly, s32 idx) // 0x80060044
     setXY1Fast(*poly, (u16)ptr->field_144.vx + (u16)ptr->field_14C, ptr->field_144.vy - ptr->field_14C);
     setXY2Fast(*poly, (u16)ptr->field_144.vx - (u16)ptr->field_14C, ptr->field_144.vy + ptr->field_14C);
     setXY3Fast(*poly, (u16)ptr->field_144.vx + (u16)ptr->field_14C, ptr->field_144.vy + ptr->field_14C);
+    if (g_PsxUsePgxp)
+    {
+        Shadow_CopyScreenOffset(&(*poly)->x0, &ptr->field_144);
+        Shadow_CopyScreenOffset(&(*poly)->x1, &ptr->field_144);
+        Shadow_CopyScreenOffset(&(*poly)->x2, &ptr->field_144);
+        Shadow_CopyScreenOffset(&(*poly)->x3, &ptr->field_144);
+    }
 
     var_a2    = (g_MapOverlayHdr.unkTable1_4C[idx].field_C.s_1.field_0) >> 3;
     temp_a2_2 = var_a2;
@@ -1319,6 +1332,15 @@ bool func_80060044(POLY_FT4** poly, s32 idx) // 0x80060044
             *(s32*)&(*poly)->u0 = (((ptr->field_164 << 5) + ptr->field_154) << 8) + 0x930000 + ((ptr->field_150 << 5) + ptr->field_168);
 
             *(*poly + 1) = **poly;
+#ifdef SH_PC_PORT
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_Copy(&(*poly + 1)->x0, &(*poly)->x0);
+                Shadow_Copy(&(*poly + 1)->x1, &(*poly)->x1);
+                Shadow_Copy(&(*poly + 1)->x2, &(*poly)->x2);
+                Shadow_Copy(&(*poly + 1)->x3, &(*poly)->x3);
+            }
+#endif
 
             *(u16*)&(*poly + 1)->r0 = ptr->field_134.r + ((ptr->field_134.g >> 4) << 8);
             (*poly + 1)->b0         = ptr->field_134.b >> 4;
@@ -1373,6 +1395,21 @@ bool func_80060044(POLY_FT4** poly, s32 idx) // 0x80060044
              * SetPriority DR_MODE prims; each POLY_FT4 carries its own ABR.
              * Garbage-size + OOB-bucket guards stay. */
             *(*poly + 3) = *(*poly + 2) = *(*poly + 1) = **poly;
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_Copy(&(*poly + 1)->x0, &(*poly)->x0);
+                Shadow_Copy(&(*poly + 1)->x1, &(*poly)->x1);
+                Shadow_Copy(&(*poly + 1)->x2, &(*poly)->x2);
+                Shadow_Copy(&(*poly + 1)->x3, &(*poly)->x3);
+                Shadow_Copy(&(*poly + 2)->x0, &(*poly)->x0);
+                Shadow_Copy(&(*poly + 2)->x1, &(*poly)->x1);
+                Shadow_Copy(&(*poly + 2)->x2, &(*poly)->x2);
+                Shadow_Copy(&(*poly + 2)->x3, &(*poly)->x3);
+                Shadow_Copy(&(*poly + 3)->x0, &(*poly)->x0);
+                Shadow_Copy(&(*poly + 3)->x1, &(*poly)->x1);
+                Shadow_Copy(&(*poly + 3)->x2, &(*poly)->x2);
+                Shadow_Copy(&(*poly + 3)->x3, &(*poly)->x3);
+            }
             *(u16*)&(*poly + 1)->r0 = ptr->field_134.r + (ptr->field_134.g << 8);
             (*poly + 1)->b0         = ptr->field_134.b;
             (*poly)->tpage          = 43;
@@ -1618,6 +1655,19 @@ bool func_800611C0(POLY_FT4** poly, s32 idx) // 0x800611C0
                            Q12_TO_Q8(g_MapOverlayHdr.unkTable1_4C[idx].field_0.vx_0 - ptr->field_178) - (u16)ptr->field_0.field_0.vx,
                            Q12_TO_Q8(g_MapOverlayHdr.unkTable1_4C[idx].vy_8) - ptr->field_0.field_0.vy,
                            Q12_TO_Q8(g_MapOverlayHdr.unkTable1_4C[idx].field_4.vz_4 - ptr->field_178) - ptr->field_0.field_0.vz);
+#ifdef SH_PC_PORT
+    {
+        const s32 x = g_MapOverlayHdr.unkTable1_4C[idx].field_0.vx_0;
+        const s32 y = g_MapOverlayHdr.unkTable1_4C[idx].vy_8;
+        const s32 z = g_MapOverlayHdr.unkTable1_4C[idx].field_4.vz_4;
+        const s32 bx = Q8_TO_Q12((s16)ptr->field_0.field_0.vx);
+        const s32 by = Q8_TO_Q12(ptr->field_0.field_0.vy);
+        const s32 bz = Q8_TO_Q12(ptr->field_0.field_0.vz);
+        PGXP_VectorRegisterQ12(&ptr->field_134, x - ptr->field_178 - bx, y - by, z + ptr->field_178 - bz);
+        PGXP_VectorRegisterQ12(&ptr->field_13C, x + ptr->field_178 - bx, y - by, z + ptr->field_178 - bz);
+        PGXP_VectorRegisterQ12(&ptr->field_144, x - ptr->field_178 - bx, y - by, z - ptr->field_178 - bz);
+    }
+#endif
 
     gte_ldv3c(&ptr->field_134);
     gte_rtpt();
@@ -1628,6 +1678,12 @@ bool func_800611C0(POLY_FT4** poly, s32 idx) // 0x800611C0
                            Q12_TO_Q8(g_MapOverlayHdr.unkTable1_4C[idx].field_0.vx_0 + ptr->field_178) - (u16)ptr->field_0.field_0.vx,
                            Q12_TO_Q8(g_MapOverlayHdr.unkTable1_4C[idx].vy_8) - ptr->field_0.field_0.vy,
                            Q12_TO_Q8(g_MapOverlayHdr.unkTable1_4C[idx].field_4.vz_4 - ptr->field_178) - ptr->field_0.field_0.vz);
+#ifdef SH_PC_PORT
+    PGXP_VectorRegisterQ12(&ptr->field_134,
+                           g_MapOverlayHdr.unkTable1_4C[idx].field_0.vx_0 + ptr->field_178 - Q8_TO_Q12((s16)ptr->field_0.field_0.vx),
+                           g_MapOverlayHdr.unkTable1_4C[idx].vy_8 - Q8_TO_Q12(ptr->field_0.field_0.vy),
+                           g_MapOverlayHdr.unkTable1_4C[idx].field_4.vz_4 - ptr->field_178 - Q8_TO_Q12(ptr->field_0.field_0.vz));
+#endif
 
     gte_ldv0(&ptr->field_134);
     gte_rtps();
@@ -1652,6 +1708,10 @@ bool func_800611C0(POLY_FT4** poly, s32 idx) // 0x800611C0
     }
 
     *(s32*)&(*poly)->x3 = *(s32*)&ptr->field_16C;
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_Copy(&(*poly)->x3, &ptr->field_16C);
+    }
 
     ptr->field_17C = !(g_MapOverlayHdr.unkTable1_4C[idx].field_C.s_1.field_0 & 8) << 5;
 
@@ -2098,6 +2158,12 @@ bool func_80062708(POLY_FT4** poly, s32 idx) // 0x80062708
                                    ((Q12_TO_Q8(g_MapOverlayHdr.unkTable1_4C[idx].field_0.vx_0) - (u16)ptr->field_0.field_0.vx) - (u16)ptr->field_2DC) + ((ptr->field_2DC >> 1) * j),
                                    Q12_TO_Q8(g_MapOverlayHdr.unkTable1_4C[idx].vy_8) - ptr->field_0.field_0.vy,
                                    ((Q12_TO_Q8(g_MapOverlayHdr.unkTable1_4C[idx].field_4.vz_4) - ptr->field_0.field_0.vz) - ptr->field_2DC) + ((ptr->field_2DC >> 1) * i));
+#ifdef SH_PC_PORT
+            PGXP_VectorRegisterQ12(&ptr->field_134[(i * 5) + j],
+                                   g_MapOverlayHdr.unkTable1_4C[idx].field_0.vx_0 - Q8_TO_Q12((s16)ptr->field_0.field_0.vx) - Q8_TO_Q12((u16)ptr->field_2DC) + Q8_TO_Q12((ptr->field_2DC >> 1) * j),
+                                   g_MapOverlayHdr.unkTable1_4C[idx].vy_8 - Q8_TO_Q12(ptr->field_0.field_0.vy),
+                                   g_MapOverlayHdr.unkTable1_4C[idx].field_4.vz_4 - Q8_TO_Q12(ptr->field_0.field_0.vz) - Q8_TO_Q12(ptr->field_2DC) + Q8_TO_Q12((ptr->field_2DC >> 1) * i));
+#endif
         }
     }
 
@@ -2143,6 +2209,13 @@ bool func_80062708(POLY_FT4** poly, s32 idx) // 0x80062708
             *(s32*)&(*poly)->x1 = *(s32*)&ptr->field_278[temp_a1_3 + 1];
             *(s32*)&(*poly)->x2 = *(s32*)&ptr->field_278[temp_a1_3 + 5];
             *(s32*)&(*poly)->x3 = *(s32*)&ptr->field_278[temp_a1_3 + 6];
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_Copy(&(*poly)->x0, &ptr->field_278[temp_a1_3]);
+                Shadow_Copy(&(*poly)->x1, &ptr->field_278[temp_a1_3 + 1]);
+                Shadow_Copy(&(*poly)->x2, &ptr->field_278[temp_a1_3 + 5]);
+                Shadow_Copy(&(*poly)->x3, &ptr->field_278[temp_a1_3 + 6]);
+            }
 
             temp_s2             = (j * 8) + (i << 11) + ptr->field_210;
             *(s32*)&(*poly)->u0 = (((g_MapOverlayHdr.unkTable1_4C[idx].field_C.s_1.field_1 << 6) | 0x13) << 16) + temp_s2;
@@ -2184,6 +2257,17 @@ bool func_80062708(POLY_FT4** poly, s32 idx) // 0x80062708
                 (*poly)->b0         = ptr->field_12C.b;
 
                 *(*poly + 2) = *(*poly + 1) = **poly;
+                if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+                {
+                    Shadow_Copy(&(*poly + 1)->x0, &(*poly)->x0);
+                    Shadow_Copy(&(*poly + 1)->x1, &(*poly)->x1);
+                    Shadow_Copy(&(*poly + 1)->x2, &(*poly)->x2);
+                    Shadow_Copy(&(*poly + 1)->x3, &(*poly)->x3);
+                    Shadow_Copy(&(*poly + 2)->x0, &(*poly)->x0);
+                    Shadow_Copy(&(*poly + 2)->x1, &(*poly)->x1);
+                    Shadow_Copy(&(*poly + 2)->x2, &(*poly)->x2);
+                    Shadow_Copy(&(*poly + 2)->x3, &(*poly)->x3);
+                }
 
                 (*poly)->tpage          = 43;
                 (*poly)->clut           = (*poly + 2)->clut = 147;
@@ -2575,6 +2659,12 @@ bool func_80063A50(POLY_FT4** poly, s32 idx) // 0x80063A50
                                (Q12_TO_Q8(g_MapOverlayHdr.unkTable1_4C[idx].field_0.vx_0 + ptr->field_19C.vx)) - (u16)ptr->field_0.field_0.vx,
                                (Q12_TO_Q8(g_MapOverlayHdr.unkTable1_4C[idx].vy_8 + ptr->field_19C.vy)) - ptr->field_0.field_0.vy,
                                (Q12_TO_Q8(g_MapOverlayHdr.unkTable1_4C[idx].field_4.vz_4 + ptr->field_19C.vz)) - ptr->field_0.field_0.vz);
+#ifdef SH_PC_PORT
+        PGXP_VectorRegisterQ12(&ptr->field_14C[0],
+                               g_MapOverlayHdr.unkTable1_4C[idx].field_0.vx_0 + ptr->field_19C.vx - Q8_TO_Q12((s16)ptr->field_0.field_0.vx),
+                               g_MapOverlayHdr.unkTable1_4C[idx].vy_8 + ptr->field_19C.vy - Q8_TO_Q12(ptr->field_0.field_0.vy),
+                               g_MapOverlayHdr.unkTable1_4C[idx].field_4.vz_4 + ptr->field_19C.vz - Q8_TO_Q12(ptr->field_0.field_0.vz));
+#endif
 
         gte_ldv0(&ptr->field_14C);
         gte_rtps();
@@ -2591,6 +2681,10 @@ bool func_80063A50(POLY_FT4** poly, s32 idx) // 0x80063A50
         }
 
         *(s32*)&(*poly)->x3 = *(s32*)&ptr->field_1CC;
+        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+        {
+            Shadow_Copy(&(*poly)->x3, &ptr->field_1CC);
+        }
 
         if (!(g_SysWork.field_2388.field_154.effectsInfo_0.field_0.field_0 & 3))
         {
@@ -2695,6 +2789,12 @@ bool func_80064334(POLY_FT4** poly, s32 idx) // 0x80064334
                            Q12_TO_Q8(g_MapOverlayHdr.unkTable1_4C[idx].field_0.vx_0) - (u16)ptr->field_0.field_0.vx,
                            Q12_TO_Q8((g_MapOverlayHdr.unkTable1_4C[idx].vy_8)) - ptr->field_0.field_0.vy,
                            Q12_TO_Q8(g_MapOverlayHdr.unkTable1_4C[idx].field_4.vz_4) - ptr->field_0.field_0.vz);
+#ifdef SH_PC_PORT
+    PGXP_VectorRegisterQ12(&ptr->field_138,
+                           g_MapOverlayHdr.unkTable1_4C[idx].field_0.vx_0 - Q8_TO_Q12((s16)ptr->field_0.field_0.vx),
+                           g_MapOverlayHdr.unkTable1_4C[idx].vy_8 - Q8_TO_Q12(ptr->field_0.field_0.vy),
+                           g_MapOverlayHdr.unkTable1_4C[idx].field_4.vz_4 - Q8_TO_Q12(ptr->field_0.field_0.vz));
+#endif
 
     gte_ldv0(&ptr->field_138);
     gte_rtps();
@@ -2745,6 +2845,13 @@ bool func_80064334(POLY_FT4** poly, s32 idx) // 0x80064334
     setXY1Fast(*poly, (u16)ptr->field_154.vx + (u16)ptr->field_160, ptr->field_154.vy - ptr->field_160);
     setXY2Fast(*poly, (u16)ptr->field_154.vx - (u16)ptr->field_160, ptr->field_154.vy + ptr->field_160);
     setXY3Fast(*poly, (u16)ptr->field_154.vx + (u16)ptr->field_160, ptr->field_154.vy + ptr->field_160);
+    if (g_PsxUsePgxp)
+    {
+        Shadow_CopyScreenOffset(&(*poly)->x0, &ptr->field_154);
+        Shadow_CopyScreenOffset(&(*poly)->x1, &ptr->field_154);
+        Shadow_CopyScreenOffset(&(*poly)->x2, &ptr->field_154);
+        Shadow_CopyScreenOffset(&(*poly)->x3, &ptr->field_154);
+    }
 
     *(s32*)&(*poly)->u0 = (((g_MapOverlayHdr.unkTable1_4C[idx].field_B << 5) + 160) << 8) + 0x011300E0;
     *(s32*)&(*poly)->u1 = (((g_MapOverlayHdr.unkTable1_4C[idx].field_B << 5) + 160) << 8) + 0x2B00FF;
@@ -2930,6 +3037,13 @@ bool func_80064FC0(POLY_FT4** polys, s32 idx) // 0x80064FC0
     setXY1Fast(*polys, (u16)ptr->field_13C.vx + (u16)ptr->field_144, ptr->field_13C.vy + ptr->field_144);
     setXY2Fast(*polys, (u16)ptr->field_13C.vx - (u16)ptr->field_144, ptr->field_13C.vy - ptr->field_144);
     setXY3Fast(*polys, (u16)ptr->field_13C.vx + (u16)ptr->field_144, ptr->field_13C.vy - ptr->field_144);
+    if (g_PsxUsePgxp)
+    {
+        Shadow_CopyScreenOffset(&(*polys)->x0, &ptr->field_13C);
+        Shadow_CopyScreenOffset(&(*polys)->x1, &ptr->field_13C);
+        Shadow_CopyScreenOffset(&(*polys)->x2, &ptr->field_13C);
+        Shadow_CopyScreenOffset(&(*polys)->x3, &ptr->field_13C);
+    }
     *(u16*)&(*polys)->r0 = 0x1020;
     (*polys)->b0         = 0x10;
 

--- a/src/bodyprog/bodyprog_800652F4.c
+++ b/src/bodyprog/bodyprog_800652F4.c
@@ -99,6 +99,12 @@ void func_800652F4(VECTOR3* arg0, s16 arg1, s16 arg2, s16 arg3) // 0x800652F4
                                    Q12_TO_Q8((arg0->vx + FP_FROM(Q12_MULT(ptr->field_60[j], Math_Sin(ptr->field_50)) * Math_Cos(arg1) - ptr->field_54[j] * Math_Sin(arg1), Q12_SHIFT))) - (u16)ptr->field_40.vx,
                                    Q12_TO_Q8((arg0->vy + Q12_MULT(ptr->field_60[j], Math_Cos(ptr->field_50)))) - ptr->field_40.vy,
                                    Q12_TO_Q8((arg0->vz + (((Q12_MULT(ptr->field_60[j], Math_Sin(ptr->field_50)) * Math_Sin(arg1)) + (ptr->field_54[j] * Math_Cos(arg1))) >> Q12_SHIFT))) - ptr->field_40.vz);
+#ifdef SH_PC_PORT
+            PGXP_VectorRegisterQ12(&ptr->field_8[j],
+                                   arg0->vx + FP_FROM(Q12_MULT(ptr->field_60[j], Math_Sin(ptr->field_50)) * Math_Cos(arg1) - ptr->field_54[j] * Math_Sin(arg1), Q12_SHIFT) - Q8_TO_Q12((s16)ptr->field_40.vx),
+                                   arg0->vy + Q12_MULT(ptr->field_60[j], Math_Cos(ptr->field_50)) - Q8_TO_Q12(ptr->field_40.vy),
+                                   arg0->vz + (((Q12_MULT(ptr->field_60[j], Math_Sin(ptr->field_50)) * Math_Sin(arg1)) + (ptr->field_54[j] * Math_Cos(arg1))) >> Q12_SHIFT) - Q8_TO_Q12(ptr->field_40.vz));
+#endif
         }
 
         gte_ldv3c(&ptr->field_8);
@@ -131,6 +137,13 @@ void func_800652F4(VECTOR3* arg0, s16 arg1, s16 arg2, s16 arg3) // 0x800652F4
             setXY1Fast(ptr->field_0, sp10[temp_a1][j].vx, sp10[temp_a1][j].vy);
             setXY2Fast(ptr->field_0, sp10[i][j + 1].vx, sp10[i][j + 1].vy);
             setXY3Fast(ptr->field_0, sp10[temp_a1][j + 1].vx, sp10[temp_a1][j + 1].vy);
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_Copy(&ptr->field_0->x0, &sp10[i][j]);
+                Shadow_Copy(&ptr->field_0->x1, &sp10[temp_a1][j]);
+                Shadow_Copy(&ptr->field_0->x2, &sp10[i][j + 1]);
+                Shadow_Copy(&ptr->field_0->x3, &sp10[temp_a1][j + 1]);
+            }
 
             ptr->field_68 = (sp190[i][j] + sp190[temp_a1][j] + sp190[i][j + 1] + sp190[temp_a1][j + 1]) >> 2;
             setSemiTrans(ptr->field_0, true);
@@ -192,6 +205,12 @@ void func_80065B94(VECTOR3* arg0, s16 arg1) // 0x80065B94
                            temp,
                            Q12_TO_Q8(arg0->vy) - ptr->field_2C.vy,
                            Q12_TO_Q8(arg0->vz) - ptr->field_2C.vz);
+#ifdef SH_PC_PORT
+    PGXP_VectorRegisterQ12(&ptr->field_4,
+                           arg0->vx - Q8_TO_Q12(ptr->field_2C.vx),
+                           arg0->vy - Q8_TO_Q12(ptr->field_2C.vy),
+                           arg0->vz - Q8_TO_Q12(ptr->field_2C.vz));
+#endif
 
     gte_ldv0(&ptr->field_4);
     gte_rtps();
@@ -244,6 +263,15 @@ void func_80065B94(VECTOR3* arg0, s16 arg1) // 0x80065B94
         setXY1Fast(ptr->field_0, (u16)ptr->field_3C.vx + (u16)ptr->field_44.vx, ptr->field_3C.vy + ptr->field_48.vx);
         setXY2Fast(ptr->field_0, (u16)ptr->field_3C.vx + (u16)ptr->field_44.vy, ptr->field_3C.vy + ptr->field_48.vy);
         setXY3Fast(ptr->field_0, (u16)ptr->field_44.vy + ((u16)ptr->field_3C.vx + (u16)ptr->field_44.vx), ptr->field_3C.vy + ptr->field_48.vx + ptr->field_48.vy);
+#ifdef SH_PC_PORT
+        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+        {
+            Shadow_CopyScreenOffset(&ptr->field_0->x0, &ptr->field_3C);
+            Shadow_CopyScreenOffset(&ptr->field_0->x1, &ptr->field_3C);
+            Shadow_CopyScreenOffset(&ptr->field_0->x2, &ptr->field_3C);
+            Shadow_CopyScreenOffset(&ptr->field_0->x3, &ptr->field_3C);
+        }
+#endif
 
         *(u16*)&ptr->field_0->r0 = ((128 - (temp2 >> 5)) << 8) - (((temp2 * 5) >> 7) - 160);
         ptr->field_0->b0         = 96 - ((temp2 * 3) >> 7);
@@ -287,12 +315,23 @@ void func_80066184(void) // 0x80066184
     gte_SetTransMatrix(&ptr->field_4);
     gte_ReadGeomScreen(&ptr->field_48);
 
+#ifdef SH_PC_PORT
+    const s32 exactBaseX = ptr->field_3C.vx;
+    const s32 exactBaseY = ptr->field_3C.vy;
+    const s32 exactBaseZ = ptr->field_3C.vz;
+#endif
     for (i = 0; i < 4; i++)
     {
         Math_SetSVectorFastSum(&ptr->field_24[i],
                                Q12_TO_Q8(D_800AE71C[i][0] - ptr->field_3C.vx),
                                Q12_TO_Q8(-81 - ptr->field_3C.vy),
                                Q12_TO_Q8(D_800AE71C[i][1] - ptr->field_3C.vz));
+#ifdef SH_PC_PORT
+        PGXP_VectorRegisterQ12(&ptr->field_24[i],
+                               D_800AE71C[i][0] - exactBaseX,
+                               -81 - exactBaseY,
+                               D_800AE71C[i][1] - exactBaseZ);
+#endif
     }
 
     gte_ldv3c(&ptr->field_24);
@@ -312,6 +351,13 @@ void func_80066184(void) // 0x80066184
     setXY1Fast(ptr->field_0, (u16)ptr->field_50.vx, ptr->field_50.vy);
     setXY2Fast(ptr->field_0, (u16)ptr->field_54.vx, ptr->field_54.vy);
     setXY3Fast(ptr->field_0, (u16)ptr->field_58.vx, ptr->field_58.vy);
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_Copy(&ptr->field_0->x0, &ptr->field_4C);
+        Shadow_Copy(&ptr->field_0->x1, &ptr->field_50);
+        Shadow_Copy(&ptr->field_0->x2, &ptr->field_54);
+        Shadow_Copy(&ptr->field_0->x3, &ptr->field_58);
+    }
 
     ptr->field_6C = MIN(FP_MULTIPLY(CLAMP_MIN_THEN_LOW(D_800AE73C, Q12(0.0f), Q12(1.0f)),
                                     func_80055D78(Q12(22.7f), Q12(0.0f), Q12(-22.1f)), Q12_SHIFT),
@@ -342,6 +388,13 @@ void func_80066184(void) // 0x80066184
 
     poly  = ptr->field_0 + 1;
     *poly = *ptr->field_0;
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_Copy(&poly->x0, &ptr->field_0->x0);
+        Shadow_Copy(&poly->x1, &ptr->field_0->x1);
+        Shadow_Copy(&poly->x2, &ptr->field_0->x2);
+        Shadow_Copy(&poly->x3, &ptr->field_0->x3);
+    }
 
     *(u32*)&ptr->field_0->u0 = 0xE0000;
     *(u32*)&ptr->field_0->u1 = 0x2D003F;

--- a/src/bodyprog/game_boot/load_screen.c
+++ b/src/bodyprog/game_boot/load_screen.c
@@ -33,6 +33,9 @@ static void Math_MatrixTransform(VECTOR3* pos, SVECTOR* rot, GsCOORDINATE2* coor
     coord->coord.t[0] = Q12_TO_Q8(pos->vx);
     coord->coord.t[1] = Q12_TO_Q8(pos->vy);
     coord->coord.t[2] = Q12_TO_Q8(pos->vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&coord->coord, pos->vx, pos->vy, pos->vz);
+#endif
 
     Math_RotMatrixZxyNegGte(rot, (MATRIX*)&coord->coord);
 }

--- a/src/bodyprog/gfx/bodyprog_80040B74.c
+++ b/src/bodyprog/gfx/bodyprog_80040B74.c
@@ -201,6 +201,86 @@ void func_80041074(GsOT* ot, s32 arg1, SVECTOR* rot, const VECTOR3* pos) // 0x80
     func_800414E0(ot, &pos0, arg1, rotY, rotX);
 }
 
+#ifdef SH_PC_PORT
+/* Precise twin of func_8004137C. The legacy integer function still produces
+ * every visible/gameplay value; this only records the discarded sub-pixel
+ * projection after applying the same H/2 near-plane intersection. */
+static void PGXP_StoreFlashlightProjection(VECTOR3* result,
+                                           const double offset0[3],
+                                           const double offset1[3],
+                                           const VECTOR* legacyOffset1,
+                                           s32 screenDist)
+{
+    double viewX;
+    double viewY;
+    double viewZ;
+    double denominator;
+    double step;
+    s32    offsetX;
+    s32    offsetY;
+
+    if (!g_PsxUsePgxp)
+    {
+        return;
+    }
+
+    viewX = offset0[0];
+    viewY = offset0[1];
+    viewZ = offset0[2];
+
+    /* func_8004137C clips a center nearer than H/2 onto that plane along the
+     * flashlight direction. Use exact translation/rotation for the twin, but
+     * retain its divide-by-one guard when the integer direction Z is zero. */
+    if ((double)(screenDist / 2) >= viewZ)
+    {
+        denominator = (legacyOffset1->vz != 0) ? offset1[2] : 1.0;
+        if (denominator == 0.0)
+        {
+            denominator = (legacyOffset1->vz != 0) ? (double)legacyOffset1->vz : 1.0;
+        }
+
+        step  = ((double)(screenDist / 2) - viewZ) / denominator;
+        viewX = viewX + (offset1[0] * step);
+        viewY = viewY + (offset1[1] * step);
+        viewZ = (double)(screenDist / 2);
+    }
+
+    ReadGeomOffset(&offsetX, &offsetY);
+    if (viewZ > 0.0)
+    {
+        PGXP_StoreManualProjection(result,
+            (float)((viewX * (double)screenDist / viewZ) + (double)offsetX),
+            (float)((viewY * (double)screenDist / viewZ) + (double)offsetY),
+            (float)viewZ);
+    }
+    else
+    {
+        /* A non-positive W is deliberately stored and rejected by the copy
+         * helper, invalidating any shadow at a reused packet address. */
+        PGXP_StoreManualProjection(result, (float)result->vx, (float)result->vy, 0.0f);
+    }
+}
+
+#define PGXP_COPY_MANUAL_TRI(poly, center) do {                              \
+        if (g_PsxUsePgxp)                                                    \
+        {                                                                    \
+            PGXP_CopyManualProjectionScreenOffset(&(poly)->x0, (center));   \
+            PGXP_CopyManualProjectionScreenOffset(&(poly)->x1, (center));   \
+            PGXP_CopyManualProjectionScreenOffset(&(poly)->x2, (center));   \
+        }                                                                    \
+    } while (0)
+
+#define PGXP_COPY_MANUAL_QUAD(poly, center) do {                             \
+        if (g_PsxUsePgxp)                                                    \
+        {                                                                    \
+            PGXP_CopyManualProjectionScreenOffset(&(poly)->x0, (center));   \
+            PGXP_CopyManualProjectionScreenOffset(&(poly)->x1, (center));   \
+            PGXP_CopyManualProjectionScreenOffset(&(poly)->x2, (center));   \
+            PGXP_CopyManualProjectionScreenOffset(&(poly)->x3, (center));   \
+        }                                                                    \
+    } while (0)
+#endif
+
 void func_800410D8(VECTOR3* pos0, q19_12* azimuthAngle, q19_12* altitudeAngle, SVECTOR* rot, const VECTOR3* pos1) // 0x800410D8
 {
     MATRIX        transformMat;
@@ -209,6 +289,12 @@ void func_800410D8(VECTOR3* pos0, q19_12* azimuthAngle, q19_12* altitudeAngle, S
     VECTOR        offset0; // Q19.12
     VECTOR        offset1; // Q19.12
     s32           flag;
+#ifdef SH_PC_PORT
+    double        exactTranslation[3];
+    double        exactRotation[9];
+    s32           hasExactTranslation;
+    s32           hasExactRotation;
+#endif
 
     memset(&vec0, 0, sizeof(SVECTOR));
 
@@ -218,9 +304,23 @@ void func_800410D8(VECTOR3* pos0, q19_12* azimuthAngle, q19_12* altitudeAngle, S
     coord.workm.t[0] = Q12_TO_Q8(pos1->vx);
     coord.workm.t[1] = Q12_TO_Q8(pos1->vy);
     coord.workm.t[2] = Q12_TO_Q8(pos1->vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&coord.workm, pos1->vx, pos1->vy, pos1->vz);
+#endif
     coord.flg        = true;
 
     Vw_CoordToViewSpaceMatrix(&coord, &transformMat);
+#ifdef SH_PC_PORT
+    hasExactTranslation = 0;
+    hasExactRotation    = 0;
+    if (g_PsxUsePgxp)
+    {
+        /* Query before SetTransMatrix installs the registers. vec0 is zero, so
+         * transformMat's exact translation is the exact view-space center. */
+        hasExactTranslation = PGXP_MatrixLookupTranslation(&transformMat, exactTranslation);
+        hasExactRotation    = PGXP_MatrixLookup(&transformMat, exactRotation);
+    }
+#endif
     SetRotMatrix(&transformMat);
     SetTransMatrix(&transformMat);
     RotTrans(&vec0, &offset0, &flag);
@@ -229,6 +329,33 @@ void func_800410D8(VECTOR3* pos0, q19_12* azimuthAngle, q19_12* altitudeAngle, S
 
     Math_RelativeRotationGet(azimuthAngle, altitudeAngle, &offset0, &offset1);
     func_8004137C(pos0, &offset0, &offset1, ReadGeomScreen());
+#ifdef SH_PC_PORT
+    if (g_PsxUsePgxp)
+    {
+        double preciseOffset0[3];
+        double preciseOffset1[3];
+
+        preciseOffset0[0] = hasExactTranslation ? exactTranslation[0] : (double)offset0.vx;
+        preciseOffset0[1] = hasExactTranslation ? exactTranslation[1] : (double)offset0.vy;
+        preciseOffset0[2] = hasExactTranslation ? exactTranslation[2] : (double)offset0.vz;
+
+        if (hasExactRotation)
+        {
+            preciseOffset1[0] = exactRotation[0] * rot->vx + exactRotation[1] * rot->vy + exactRotation[2] * rot->vz;
+            preciseOffset1[1] = exactRotation[3] * rot->vx + exactRotation[4] * rot->vy + exactRotation[5] * rot->vz;
+            preciseOffset1[2] = exactRotation[6] * rot->vx + exactRotation[7] * rot->vy + exactRotation[8] * rot->vz;
+        }
+        else
+        {
+            preciseOffset1[0] = (double)offset1.vx;
+            preciseOffset1[1] = (double)offset1.vy;
+            preciseOffset1[2] = (double)offset1.vz;
+        }
+
+        PGXP_StoreFlashlightProjection(pos0, preciseOffset0, preciseOffset1,
+                                       &offset1, ReadGeomScreen());
+    }
+#endif
 }
 
 void Math_RelativeRotationGet(q19_12* azimuthAngle, q19_12* altitudeAngle, const VECTOR* offsetFrom, const VECTOR* offsetTo) // 0x8004122C
@@ -388,6 +515,9 @@ void func_800414E0(GsOT* arg0, VECTOR3* arg1, s32 arg2, q19_12 angle0, q19_12 an
         poly_g3->y0         = arg1->vy;
         *(s32*)&poly_g3->x1 = var_t0[j];
         *(s32*)&poly_g3->x2 = var_t0[j + 1];
+#ifdef SH_PC_PORT
+        PGXP_COPY_MANUAL_TRI(poly_g3, arg1);
+#endif
 
 #ifdef SH_PC_PORT
         if (!g_PsyX_FlashlightActive)
@@ -396,6 +526,9 @@ void func_800414E0(GsOT* arg0, VECTOR3* arg1, s32 arg2, q19_12 angle0, q19_12 an
 
         *(s32*)&poly_f4->x0 = var_t0[j + 51];
         *(s32*)&poly_f4->x1 = var_t0[j + 52];
+#ifdef SH_PC_PORT
+        PGXP_COPY_MANUAL_QUAD(poly_f4, arg1);
+#endif
 
         addPrim(&arg0->org[1], poly_f4);
     }
@@ -413,6 +546,9 @@ void func_800414E0(GsOT* arg0, VECTOR3* arg1, s32 arg2, q19_12 angle0, q19_12 an
             *(s32*)&poly_g4->x1 = var_a1_3[j + 1];
             *(s32*)&poly_g4->x2 = var_a1_3[17 + j];
             *(s32*)&poly_g4->x3 = var_a1_3[(17 + j) + 1];
+#ifdef SH_PC_PORT
+            PGXP_COPY_MANUAL_QUAD(poly_g4, arg1);
+#endif
 
             addPrim(&arg0->org[1], poly_g4);
         }

--- a/src/bodyprog/gfx/bodyprog_80055028.c
+++ b/src/bodyprog/gfx/bodyprog_80055028.c
@@ -2421,6 +2421,20 @@ void Gfx_MeshDraw(s_MeshHeader* meshHdr, s_GteScratchData* scratchData, GsOT_TAG
                                    *(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_11],
                                    *(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_12], &sp10);
 
+#ifdef SH_PC_PORT
+                    {
+                        s32 _sp10b = 0;
+                        extern int PsyX_PGXP_QuadBackface(const void*, const void*, const void*, const void*, int, int);
+                        gte_ldsxy0(*(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_13]);
+                        gte_nclip();
+                        gte_stopz(&_sp10b);
+                        if (PsyX_PGXP_QuadBackface(&scratchData->screenXy_0[scratchData->field_380.s_0.field_10],
+                                                   &scratchData->screenXy_0[scratchData->field_380.s_0.field_11],
+                                                   &scratchData->screenXy_0[scratchData->field_380.s_0.field_12],
+                                                   &scratchData->screenXy_0[scratchData->field_380.s_0.field_13], sp10, _sp10b))
+                            continue;
+                    }
+#else
                     if (sp10 <= 0)
                     {
                         gte_ldsxy0(*(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_13]);
@@ -2432,6 +2446,7 @@ void Gfx_MeshDraw(s_MeshHeader* meshHdr, s_GteScratchData* scratchData, GsOT_TAG
                             continue;
                         }
                     }
+#endif
 
                     temp_a3 = scratchData->field_380.s_0.field_0;
                     temp_a2 = *(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_10];
@@ -2643,6 +2658,20 @@ void Gfx_MeshDraw(s_MeshHeader* meshHdr, s_GteScratchData* scratchData, GsOT_TAG
                 gte_nclip();
                 gte_stopz(&sp14);
 
+#ifdef SH_PC_PORT
+                {
+                    s32 _sp14b = 0;
+                    extern int PsyX_PGXP_QuadBackface(const void*, const void*, const void*, const void*, int, int);
+                    gte_ldsxy0(*(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_13]);
+                    gte_nclip();
+                    gte_stopz(&_sp14b);
+                    if (PsyX_PGXP_QuadBackface(&scratchData->screenXy_0[scratchData->field_380.s_0.field_10],
+                                               &scratchData->screenXy_0[scratchData->field_380.s_0.field_11],
+                                               &scratchData->screenXy_0[scratchData->field_380.s_0.field_12],
+                                               &scratchData->screenXy_0[scratchData->field_380.s_0.field_13], sp14, _sp14b))
+                        continue;
+                }
+#else
                 if (sp14 <= 0)
                 {
                     gte_ldsxy0(*(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_13]);
@@ -2654,6 +2683,7 @@ void Gfx_MeshDraw(s_MeshHeader* meshHdr, s_GteScratchData* scratchData, GsOT_TAG
                         continue;
                     }
                 }
+#endif
 
                 temp_a3_2 = scratchData->field_380.s_0.field_0;
                 temp_a2_3 = *(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_10];
@@ -2784,6 +2814,20 @@ void Gfx_MeshDraw(s_MeshHeader* meshHdr, s_GteScratchData* scratchData, GsOT_TAG
             gte_nclip();
             gte_stopz(&sp18);
 
+#ifdef SH_PC_PORT
+            {
+                s32 _sp18b = 0;
+                extern int PsyX_PGXP_QuadBackface(const void*, const void*, const void*, const void*, int, int);
+                gte_ldsxy0(*(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_13]);
+                gte_nclip();
+                gte_stopz(&_sp18b);
+                if (PsyX_PGXP_QuadBackface(&scratchData->screenXy_0[scratchData->field_380.s_0.field_10],
+                                           &scratchData->screenXy_0[scratchData->field_380.s_0.field_11],
+                                           &scratchData->screenXy_0[scratchData->field_380.s_0.field_12],
+                                           &scratchData->screenXy_0[scratchData->field_380.s_0.field_13], sp18, _sp18b))
+                    continue;
+            }
+#else
             if (sp18 <= 0)
             {
                 gte_ldsxy0(*(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_13]);
@@ -2795,6 +2839,7 @@ void Gfx_MeshDraw(s_MeshHeader* meshHdr, s_GteScratchData* scratchData, GsOT_TAG
                     continue;
                 }
             }
+#endif
 
             temp_a3_4 = scratchData->field_380.s_0.field_0;
             temp_a2_5 = *(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_10];
@@ -3019,6 +3064,20 @@ __block1530:
         gte_nclip();
         gte_stopz(&sp1C);
 
+#ifdef SH_PC_PORT
+        {
+            s32 _sp1Cb = 0;
+            extern int PsyX_PGXP_QuadBackface(const void*, const void*, const void*, const void*, int, int);
+            gte_ldsxy0(*(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_13]);
+            gte_nclip();
+            gte_stopz(&_sp1Cb);
+            if (PsyX_PGXP_QuadBackface(&scratchData->screenXy_0[scratchData->field_380.s_0.field_10],
+                                       &scratchData->screenXy_0[scratchData->field_380.s_0.field_11],
+                                       &scratchData->screenXy_0[scratchData->field_380.s_0.field_12],
+                                       &scratchData->screenXy_0[scratchData->field_380.s_0.field_13], sp1C, _sp1Cb))
+                continue;
+        }
+#else
         if (sp1C <= 0)
         {
             gte_ldsxy0(*(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_13]);
@@ -3030,6 +3089,7 @@ __block1530:
                 continue;
             }
         }
+#endif
 
         temp_a3_3 = scratchData->field_380.s_0.field_0;
         temp_a2_4 = *(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_10];
@@ -3222,6 +3282,20 @@ __block19CC:
         gte_nclip();
         gte_stopz(&sp20);
 
+#ifdef SH_PC_PORT
+        {
+            s32 _sp20b = 0;
+            extern int PsyX_PGXP_QuadBackface(const void*, const void*, const void*, const void*, int, int);
+            gte_ldsxy0(*(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_13]);
+            gte_nclip();
+            gte_stopz(&_sp20b);
+            if (PsyX_PGXP_QuadBackface(&scratchData->screenXy_0[scratchData->field_380.s_0.field_10],
+                                       &scratchData->screenXy_0[scratchData->field_380.s_0.field_11],
+                                       &scratchData->screenXy_0[scratchData->field_380.s_0.field_12],
+                                       &scratchData->screenXy_0[scratchData->field_380.s_0.field_13], sp20, _sp20b))
+                continue;
+        }
+#else
         if (sp20 <= 0)
         {
             gte_ldsxy0(*(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_13]);
@@ -3233,6 +3307,7 @@ __block19CC:
                 continue;
             }
         }
+#endif
 
         temp_a3_5 = scratchData->field_380.s_0.field_0;
         temp_a2_7 = *(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_10];
@@ -3400,6 +3475,20 @@ void func_80059E34(u32 arg0, s_MeshHeader* meshHdr, s_GteScratchData* scratchDat
                        *(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_12],
                        &sp0);
 
+#ifdef SH_PC_PORT
+        {
+            s32 _sp0b = 0;
+            extern int PsyX_PGXP_QuadBackface(const void*, const void*, const void*, const void*, int, int);
+            gte_ldsxy0(*(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_13]);
+            gte_nclip();
+            gte_stopz(&_sp0b);
+            if (PsyX_PGXP_QuadBackface(&scratchData->screenXy_0[scratchData->field_380.s_0.field_10],
+                                       &scratchData->screenXy_0[scratchData->field_380.s_0.field_11],
+                                       &scratchData->screenXy_0[scratchData->field_380.s_0.field_12],
+                                       &scratchData->screenXy_0[scratchData->field_380.s_0.field_13], sp0, _sp0b))
+                continue;
+        }
+#else
         if (sp0 <= 0)
         {
             gte_ldsxy0(*(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_13]);
@@ -3411,6 +3500,7 @@ void func_80059E34(u32 arg0, s_MeshHeader* meshHdr, s_GteScratchData* scratchDat
                 continue;
             }
         }
+#endif
 
         temp = *(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_10];
         x1 = *(s32*)&scratchData->screenXy_0[scratchData->field_380.s_0.field_11];
@@ -4667,12 +4757,17 @@ void Gfx_BillboardDraw(s32 arg0, q19_12 posX, q19_12 posY, q19_12 posZ, GsOT* ot
                 }
                 poly_gt4->pad2 = poly_gt4->p1; /* v0 fog (uniform billboard) */
 
-                /* PGXP: billboard corners are built in screen space from the one
-                 * projected centre (field_1C) — the 4th vertex IS that centre, so
-                 * with PGXP it alone matches the ring (centre W) while the other
-                 * corners go affine, warping the quad ("tree-foliage spikes").
-                 * Billboards are camera-facing flat quads, so affine is correct. */
-                PsyX_SetNextPrimAffine();
+                /* Keep the GTE centre's exact fractional projection on every
+                 * screen-derived corner. All four corners share one W, so the
+                 * billboard remains intentionally affine while its outline moves
+                 * continuously instead of snapping to whole PSX pixels. */
+                if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+                {
+                    Shadow_CopyScreenOffset(&poly_gt4->x0, &field_1C);
+                    Shadow_CopyScreenOffset(&poly_gt4->x1, &field_1C);
+                    Shadow_CopyScreenOffset(&poly_gt4->x2, &field_1C);
+                    Shadow_CopyScreenOffset(&poly_gt4->x3, &field_1C);
+                }
                 addPrim(&ot_arg4->org[MIN(temp_v0_2 >> arg5, ORDERING_TABLE_SIZE - 1)], poly_gt4);
                 poly_gt4++;
             }

--- a/src/bodyprog/gfx/map_effects.c
+++ b/src/bodyprog/gfx/map_effects.c
@@ -1,4 +1,5 @@
 #include "game.h"
+#include "inline_no_dmpsx.h"
 
 #include <psyq/libetc.h>
 #include <psyq/libpad.h>
@@ -204,6 +205,15 @@ void func_8003E740(void) // 0x8003E740
 
         poly->x3 = sp10.vx + sp58.vx;
         poly->y3 = sp10.vy + sp58.vy;
+#ifdef SH_PC_PORT
+        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+        {
+            Shadow_CopyScreenOffset(&poly->x0, &sp10);
+            Shadow_CopyScreenOffset(&poly->x1, &sp10);
+            Shadow_CopyScreenOffset(&poly->x2, &sp10);
+            Shadow_CopyScreenOffset(&poly->x3, &sp10);
+        }
+#endif
 
 #ifdef SH_PC_PORT
         /* PAL FLAME sits at u=0 of its own tpage instead of u=128 of BG_ETC's. */

--- a/src/bodyprog/items/item_screens_cam.c
+++ b/src/bodyprog/items/item_screens_cam.c
@@ -142,10 +142,22 @@ void ItemScreen_ItemRotate(SVECTOR* arg0, GsCOORDINATE2* arg1) // 0x8004BCDC
     mat.t[0] = arg1->coord.t[0];
     mat.t[1] = arg1->coord.t[1];
     mat.t[2] = arg1->coord.t[2];
+#ifdef SH_PC_PORT
+    {
+        double exactTranslation[3];
+        if (PGXP_MatrixLookupTranslation(&arg1->coord, exactTranslation))
+            PGXP_MatrixRegisterTranslation(&mat, exactTranslation);
+        else
+            PGXP_MatrixInvalidateTranslation(&mat);
+    }
+#endif
 
     Math_RotMatrixZxyNegGte(arg0, &mat);
 
     arg1->coord = mat;
+#ifdef SH_PC_PORT
+    PGXP_MatrixCopyFull(&arg1->coord, &mat);
+#endif
 
     ScaleMatrix(&arg1->coord, &arg1->param->scale);
 

--- a/src/bodyprog/player_control.c
+++ b/src/bodyprog/player_control.c
@@ -9013,6 +9013,12 @@ void func_8007C0D8(s_SubCharacter* player, s_PlayerExtra* extra, GsCOORDINATE2* 
     coords->coord.t[0]                        = Q12_TO_Q8(player->position.vx);
     coords->coord.t[1]                        = Q12_TO_Q8(player->position.vy);
     coords->coord.t[2]                        = Q12_TO_Q8(player->position.vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&coords->coord,
+                                      player->position.vx,
+                                      player->position.vy,
+                                      player->position.vz);
+#endif
 }
 
 void Player_ReceiveDamage(s_SubCharacter* player, s_PlayerExtra* extra) // 0x8007C800

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -157,6 +157,9 @@ void func_80080B58(GsCOORDINATE2* arg0, SVECTOR* rot, VECTOR3* pos) // 0x80080B5
     vcWork.lookAtMat.t[0] = Q12_TO_Q8(pos->vx);
     vcWork.lookAtMat.t[1] = Q12_TO_Q8(pos->vy);
     vcWork.lookAtMat.t[2] = Q12_TO_Q8(pos->vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&vcWork.lookAtMat, pos->vx, pos->vy, pos->vz);
+#endif
 }
 
 void vcWorkSetFlags(VC_FLAGS enable, VC_FLAGS disable) // 0x80080BF8
@@ -2979,6 +2982,9 @@ void vcMakeCamMatAndCamAngByBaseAngAndOfsAng(SVECTOR* cam_mat_ang, MATRIX* cam_m
     cam_mat->t[0] = Q12_TO_Q8(cam_pos->vx);
     cam_mat->t[1] = Q12_TO_Q8(cam_pos->vy);
     cam_mat->t[2] = Q12_TO_Q8(cam_pos->vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(cam_mat, cam_pos->vx, cam_pos->vy, cam_pos->vz);
+#endif
 
     Math_RotMatrixZxyNeg(base_cam_ang, &base_mat);
     Math_RotMatrixZxyNeg(ofs_cam_ang, &ofs_mat);
@@ -3024,6 +3030,15 @@ void vcSetDataToVwSystem(VC_WORK* w_p, VC_CAM_MV_TYPE cam_mv_type) // 0x80085884
         noise_cam_mat.t[0] = w_p->cam_mat.t[0];
         noise_cam_mat.t[1] = w_p->cam_mat.t[1];
         noise_cam_mat.t[2] = w_p->cam_mat.t[2];
+#ifdef SH_PC_PORT
+        {
+            double exactTranslation[3];
+            if (PGXP_MatrixLookupTranslation(&w_p->cam_mat, exactTranslation))
+                PGXP_MatrixRegisterTranslation(&noise_cam_mat, exactTranslation);
+            else
+                PGXP_MatrixInvalidateTranslation(&noise_cam_mat);
+        }
+#endif
         vwSetViewInfoDirectMatrix(NULL, &noise_cam_mat);
     }
     else

--- a/src/bodyprog/view/vw_calc.c
+++ b/src/bodyprog/view/vw_calc.c
@@ -313,6 +313,24 @@ void vwMatrixToAngleYXZ(SVECTOR* ang, const MATRIX* mat) // 0x800495D4
 
 void Vw_MultiplyAndTransformMatrix(MATRIX* transformMat, MATRIX* inMat, MATRIX* outMat) // 0x800496AC
 {
+#ifdef SH_PC_PORT
+    double exactRot[9];
+    double exactTransformT[3];
+    double exactInputT[3];
+    double exactOutputT[3];
+    s32 haveExactTranslation =
+        PGXP_MatrixLookup(transformMat, exactRot) &&
+        PGXP_MatrixLookupTranslation(transformMat, exactTransformT) &&
+        PGXP_MatrixLookupTranslation(inMat, exactInputT);
+
+    if (haveExactTranslation)
+    {
+        exactOutputT[0] = exactTransformT[0] + exactRot[0] * exactInputT[0] + exactRot[1] * exactInputT[1] + exactRot[2] * exactInputT[2];
+        exactOutputT[1] = exactTransformT[1] + exactRot[3] * exactInputT[0] + exactRot[4] * exactInputT[1] + exactRot[5] * exactInputT[2];
+        exactOutputT[2] = exactTransformT[2] + exactRot[6] * exactInputT[0] + exactRot[7] * exactInputT[1] + exactRot[8] * exactInputT[2];
+    }
+#endif
+
     gte_SetRotMatrix(transformMat);
     gte_SetTransMatrix(transformMat);
     gte_ldclmv(inMat);
@@ -327,6 +345,13 @@ void Vw_MultiplyAndTransformMatrix(MATRIX* transformMat, MATRIX* inMat, MATRIX* 
     gte_ldlvl((VECTOR*)inMat->t);
     gte_rtirtr();
     gte_stlvnl((VECTOR*)outMat->t);
+
+#ifdef SH_PC_PORT
+    if (haveExactTranslation)
+        PGXP_MatrixRegisterTranslation(outMat, exactOutputT);
+    else
+        PGXP_MatrixInvalidateTranslation(outMat);
+#endif
 }
 
 void vbSetWorldScreenMatrix(GsCOORDINATE2* coord) // 0x800497E4
@@ -341,6 +366,12 @@ void vbSetWorldScreenMatrix(GsCOORDINATE2* coord) // 0x800497E4
     VbWvsMatrix.t[2] = Q8(0.0f);
     VbWvsMatrix.t[1] = Q8(0.0f);
     VbWvsMatrix.t[0] = Q8(0.0f);
+#ifdef SH_PC_PORT
+    {
+        const double zeroTranslation[3] = { 0.0, 0.0, 0.0 };
+        PGXP_MatrixRegisterTranslation(&VbWvsMatrix, zeroTranslation);
+    }
+#endif
 
     GsWSMATRIX.m[0][0] = VbWvsMatrix.m[0][0];
     GsWSMATRIX.m[0][1] = VbWvsMatrix.m[0][1];
@@ -351,11 +382,33 @@ void vbSetWorldScreenMatrix(GsCOORDINATE2* coord) // 0x800497E4
     GsWSMATRIX.m[2][0] = VbWvsMatrix.m[2][0];
     GsWSMATRIX.m[2][1] = VbWvsMatrix.m[2][1];
     GsWSMATRIX.m[2][2] = VbWvsMatrix.m[2][2];
+#ifdef SH_PC_PORT
+    PGXP_MatrixCopy(&GsWSMATRIX, &VbWvsMatrix);
+#endif
 
     vec.vx = -D_800C3868.t[0];
     vec.vy = -D_800C3868.t[1];
     vec.vz = -D_800C3868.t[2];
     ApplyMatrixLV(&VbWvsMatrix, &vec, (VECTOR*)&GsWSMATRIX.t);
+#ifdef SH_PC_PORT
+    {
+        double exactViewRot[9];
+        double exactCameraT[3];
+        double exactWorldScreenT[3];
+        if (PGXP_MatrixLookup(&VbWvsMatrix, exactViewRot) &&
+            PGXP_MatrixLookupTranslation(&D_800C3868, exactCameraT))
+        {
+            exactWorldScreenT[0] = -(exactViewRot[0] * exactCameraT[0] + exactViewRot[1] * exactCameraT[1] + exactViewRot[2] * exactCameraT[2]);
+            exactWorldScreenT[1] = -(exactViewRot[3] * exactCameraT[0] + exactViewRot[4] * exactCameraT[1] + exactViewRot[5] * exactCameraT[2]);
+            exactWorldScreenT[2] = -(exactViewRot[6] * exactCameraT[0] + exactViewRot[7] * exactCameraT[1] + exactViewRot[8] * exactCameraT[2]);
+            PGXP_MatrixRegisterTranslation(&GsWSMATRIX, exactWorldScreenT);
+        }
+        else
+        {
+            PGXP_MatrixInvalidateTranslation(&GsWSMATRIX);
+        }
+    }
+#endif
 }
 
 void vbSetRefView(VbRVIEW* rview) // 0x800498D8
@@ -397,6 +450,7 @@ void Vw_CoordHierarchyMatrixCompute(GsCOORDINATE2* rootCoord, MATRIX* transformM
             if (!_badRootLogged) { _badRootLogged = 1; SH_DBG("[COORD] non-canonical rootCoord=%p — identity", (void*)rootCoord); }
         }
         *transformMat = GsIDMATRIX;
+        PGXP_MatrixCopyFull(transformMat, &GsIDMATRIX);
         return;
     }
 #endif
@@ -404,6 +458,9 @@ void Vw_CoordHierarchyMatrixCompute(GsCOORDINATE2* rootCoord, MATRIX* transformM
     if (rootCoord == NULL)
     {
         *transformMat = GsIDMATRIX;
+#ifdef SH_PC_PORT
+        PGXP_MatrixCopyFull(transformMat, &GsIDMATRIX);
+#endif
     }
 
     curCoord  = rootCoord;
@@ -459,6 +516,9 @@ void Vw_CoordHierarchyMatrixCompute(GsCOORDINATE2* rootCoord, MATRIX* transformM
             if (prevCoord == NULL)
             {
                 curCoord->workm = curCoord->coord;
+#ifdef SH_PC_PORT
+                PGXP_MatrixCopyFull(&curCoord->workm, &curCoord->coord);
+#endif
             }
             else
             {
@@ -473,6 +533,9 @@ void Vw_CoordHierarchyMatrixCompute(GsCOORDINATE2* rootCoord, MATRIX* transformM
     // Set output.
     *transformMat = rootCoord->workm;
 #ifdef SH_PC_PORT
+    PGXP_MatrixCopyFull(transformMat, &rootCoord->workm);
+#endif
+#ifdef SH_PC_PORT
     #undef COORD_PTR_OK
 #endif
 }
@@ -480,32 +543,102 @@ void Vw_CoordHierarchyMatrixCompute(GsCOORDINATE2* rootCoord, MATRIX* transformM
 void Vw_CoordToViewSpaceMatrix(GsCOORDINATE2* rootCoord, MATRIX* viewMat) // 0x80049AF8
 {
     MATRIX worldMat;
+#ifdef SH_PC_PORT
+    double exactWorldT[3];
+    double exactCameraT[3];
+    double exactRelativeT[3];
+#endif
 
     Vw_CoordHierarchyMatrixCompute(rootCoord, &worldMat);
+#ifdef SH_PC_PORT
+    s32 haveExactTranslation =
+        PGXP_MatrixLookupTranslation(&worldMat, exactWorldT) &&
+        PGXP_MatrixLookupTranslation(&D_800C3868, exactCameraT);
+#endif
     worldMat.t[0] -= D_800C3868.t[0];
     worldMat.t[1] -= D_800C3868.t[1];
     worldMat.t[2] -= D_800C3868.t[2];
+#ifdef SH_PC_PORT
+    if (haveExactTranslation)
+    {
+        exactRelativeT[0] = exactWorldT[0] - exactCameraT[0];
+        exactRelativeT[1] = exactWorldT[1] - exactCameraT[1];
+        exactRelativeT[2] = exactWorldT[2] - exactCameraT[2];
+        PGXP_MatrixRegisterTranslation(&worldMat, exactRelativeT);
+    }
+    else
+    {
+        PGXP_MatrixInvalidateTranslation(&worldMat);
+    }
+#endif
 
     Vw_MultiplyAndTransformMatrix(&VbWvsMatrix, &worldMat, viewMat);
 }
 
 void Vw_CoordToWorldAndViewMatrices(GsCOORDINATE2* rootCoord, MATRIX* worldMat, MATRIX* viewMat) // 0x80049B6C
 {
+#ifdef SH_PC_PORT
+    double exactWorldT[3];
+    double exactCameraT[3];
+    double exactRelativeT[3];
+#endif
+
     Vw_CoordHierarchyMatrixCompute(rootCoord, worldMat);
+#ifdef SH_PC_PORT
+    s32 haveExactTranslation =
+        PGXP_MatrixLookupTranslation(worldMat, exactWorldT) &&
+        PGXP_MatrixLookupTranslation(&D_800C3868, exactCameraT);
+#endif
     worldMat->t[0] -= D_800C3868.t[0];
     worldMat->t[1] -= D_800C3868.t[1];
     worldMat->t[2] -= D_800C3868.t[2];
+#ifdef SH_PC_PORT
+    if (haveExactTranslation)
+    {
+        exactRelativeT[0] = exactWorldT[0] - exactCameraT[0];
+        exactRelativeT[1] = exactWorldT[1] - exactCameraT[1];
+        exactRelativeT[2] = exactWorldT[2] - exactCameraT[2];
+        PGXP_MatrixRegisterTranslation(worldMat, exactRelativeT);
+    }
+    else
+    {
+        PGXP_MatrixInvalidateTranslation(worldMat);
+    }
+#endif
 
     Vw_MultiplyAndTransformMatrix(&VbWvsMatrix, worldMat, viewMat);
     worldMat->t[0] += D_800C3868.t[0];
     worldMat->t[1] += D_800C3868.t[1];
     worldMat->t[2] += D_800C3868.t[2];
+#ifdef SH_PC_PORT
+    if (haveExactTranslation)
+        PGXP_MatrixRegisterTranslation(worldMat, exactWorldT);
+    else
+        PGXP_MatrixInvalidateTranslation(worldMat);
+#endif
 }
 
 void Vw_WorldScreenMatrixAtPositionGet(MATRIX* worldToScreenMat, q19_12 posX, q19_12 posY, q19_12 posZ) // 0x80049C2C
 {
     VECTOR in; // Q23.8
     VECTOR out;
+#ifdef SH_PC_PORT
+    double exactRot[9];
+    double exactBaseT[3];
+    double exactOutputT[3];
+    s32 haveExactTranslation =
+        PGXP_MatrixLookup(&GsWSMATRIX, exactRot) &&
+        PGXP_MatrixLookupTranslation(&GsWSMATRIX, exactBaseT);
+    if (haveExactTranslation)
+    {
+        const double x = (double)posX / 16.0;
+        const double y = (double)posY / 16.0;
+        const double z = (double)posZ / 16.0;
+        exactOutputT[0] = exactBaseT[0] + exactRot[0] * x + exactRot[1] * y + exactRot[2] * z;
+        exactOutputT[1] = exactBaseT[1] + exactRot[3] * x + exactRot[4] * y + exactRot[5] * z;
+        exactOutputT[2] = exactBaseT[2] + exactRot[6] * x + exactRot[7] * y + exactRot[8] * z;
+    }
+#endif
 
     in.vx = Q12_TO_Q8(posX);
     in.vy = Q12_TO_Q8(posY);
@@ -518,10 +651,19 @@ void Vw_WorldScreenMatrixAtPositionGet(MATRIX* worldToScreenMat, q19_12 posX, q1
     *(u32*)&worldToScreenMat->m[1][1] = *(u32*)&GsWSMATRIX.m[1][1];
     *(u32*)&worldToScreenMat->m[2][0] = *(u32*)&GsWSMATRIX.m[2][0];
     worldToScreenMat->m[2][2]         = GsWSMATRIX.m[2][2];
+#ifdef SH_PC_PORT
+    PGXP_MatrixCopy(worldToScreenMat, &GsWSMATRIX);
+#endif
 
     worldToScreenMat->t[0] = out.vx + GsWSMATRIX.t[0];
     worldToScreenMat->t[1] = out.vy + GsWSMATRIX.t[1];
     worldToScreenMat->t[2] = out.vz + GsWSMATRIX.t[2];
+#ifdef SH_PC_PORT
+    if (haveExactTranslation)
+        PGXP_MatrixRegisterTranslation(worldToScreenMat, exactOutputT);
+    else
+        PGXP_MatrixInvalidateTranslation(worldToScreenMat);
+#endif
 }
 
 bool Vw_AabbVisibleInScreenCheck(s32 minX, s32 maxX, s32 minY, s32 maxY, s32 minZ, s32 maxZ) // 0x80049D04
@@ -560,6 +702,12 @@ bool Vw_AabbVisibleInScreenCheck(s32 minX, s32 maxX, s32 minY, s32 maxY, s32 min
 		vertOffset.vx = (i & (1 << 0)) ? Q12_TO_Q8(maxX - minX) : Q8(0.0f);
 		vertOffset.vy = (i & (1 << 1)) ? Q12_TO_Q8(maxY - minY) : Q8(0.0f);
 		vertOffset.vz = (i & (1 << 2)) ? Q12_TO_Q8(maxZ - minZ) : Q8(0.0f);
+#ifdef SH_PC_PORT
+        PGXP_VectorRegisterQ12(&vertOffset,
+                               (i & (1 << 0)) ? (maxX - minX) : Q12(0.0f),
+                               (i & (1 << 1)) ? (maxY - minY) : Q12(0.0f),
+                               (i & (1 << 2)) ? (maxZ - minZ) : Q12(0.0f));
+#endif
 
 		screenDepth = RotTransPers(&vertOffset, &screenPos, &depthDmy, &depthDmy) - 1;
 
@@ -691,6 +839,9 @@ bool Vw_AabbVisibleInFrustumCheck(MATRIX* modelMat,
 
     cullData           = (s_CameraCullData*)PSX_SCRATCH;
     cullData->modelMat = *modelMat;
+#ifdef SH_PC_PORT
+    PGXP_MatrixCopyFull(&cullData->modelMat, modelMat);
+#endif
 
     ((u32*)&regionFlags)[1] = 0;
     ((u32*)&regionFlags)[0] = 0;

--- a/src/bodyprog/view/vw_main.c
+++ b/src/bodyprog/view/vw_main.c
@@ -2,6 +2,7 @@
 #ifdef SH_PC_PORT
 #include "sh_log.h"
 #include <stdio.h>
+#include <math.h>
 #endif
 
 #include "bodyprog/view/vw_main.h"
@@ -64,6 +65,9 @@ void Vw_SetLookAtMatrix(const VECTOR3* pos, const VECTOR3* lookAt) // 0x80048AF4
     viewMat.t[0] = Q12_TO_Q8(pos->vx);
     viewMat.t[1] = Q12_TO_Q8(pos->vy);
     viewMat.t[2] = Q12_TO_Q8(pos->vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&viewMat, pos->vx, pos->vy, pos->vz);
+#endif
     vwSetViewInfoDirectMatrix(NULL, &viewMat);
 }
 
@@ -91,6 +95,17 @@ void vwSetCoordRefAndEntou(GsCOORDINATE2* parent_p,
     view_mtx->t[0] = Q12_TO_Q8(ref_x) + Q12_MULT(Q12_TO_Q8(cam_xz_r), Math_Sin(cam_ang_y));
     view_mtx->t[1] = Q12_TO_Q8(ref_y) + Q12_TO_Q8(cam_y);
     view_mtx->t[2] = Q12_TO_Q8(ref_z) + Q12_MULT(Q12_TO_Q8(cam_xz_r), Math_Cos(cam_ang_y));
+#ifdef SH_PC_PORT
+    {
+        const double radians = ((double)cam_ang_y / 4096.0) * 6.28318530717958647692;
+        const double exactTranslation[3] = {
+            (double)ref_x / 16.0 + ((double)cam_xz_r / 16.0) * sin(radians),
+            (double)ref_y / 16.0 + (double)cam_y / 16.0,
+            (double)ref_z / 16.0 + ((double)cam_xz_r / 16.0) * cos(radians)
+        };
+        PGXP_MatrixRegisterTranslation(view_mtx, exactTranslation);
+    }
+#endif
 }
 
 void vwSetViewInfoDirectMatrix(GsCOORDINATE2* pcoord, const MATRIX* cammat) // 0x80048CF0
@@ -98,6 +113,9 @@ void vwSetViewInfoDirectMatrix(GsCOORDINATE2* pcoord, const MATRIX* cammat) // 0
     vwViewPointInfo.vwcoord.flg   = false;
     vwViewPointInfo.vwcoord.super = pcoord;
     vwViewPointInfo.vwcoord.coord = *cammat;
+#ifdef SH_PC_PORT
+    PGXP_MatrixCopyFull(&vwViewPointInfo.vwcoord.coord, cammat);
+#endif
 }
 
 /** @brief Extracts a position from a matrix, outputting the result to `pos`.
@@ -109,6 +127,22 @@ void vwSetViewInfoDirectMatrix(GsCOORDINATE2* pcoord, const MATRIX* cammat) // 0
  */
 static inline void Math_MatrixToPosition(VECTOR3* pos, MATRIX* mat)
 {
+#ifdef SH_PC_PORT
+    /* Preserve the Q12 camera position carried by the PGXP translation twin.
+     * llround selects the nearest representable Q12 value; if provenance was
+     * invalidated, retain the exact legacy Q8->Q12 conversion below. */
+    if (g_PsxUsePgxp)
+    {
+        double exactTranslation[3];
+        if (PGXP_MatrixLookupTranslation(mat, exactTranslation))
+        {
+            pos->vx = (s32)llround(exactTranslation[0] * 16.0);
+            pos->vy = (s32)llround(exactTranslation[1] * 16.0);
+            pos->vz = (s32)llround(exactTranslation[2] * 16.0);
+            return;
+        }
+    }
+#endif
     pos->vx = Q8_TO_Q12(mat->t[0]);
     pos->vy = Q8_TO_Q12(mat->t[1]);
     pos->vz = Q8_TO_Q12(mat->t[2]);

--- a/src/bodyprog/water.c
+++ b/src/bodyprog/water.c
@@ -358,8 +358,28 @@ extern unsigned char g_PcFlashlightColorR, g_PcFlashlightColorG, g_PcFlashlightC
         }                                                            \
         setRGB0((p), _fr, _fg, _fb);                                 \
     } while (0)
+#define PGXP_TRACK_FLARE_QUAD(poly, center) do {                       \
+        if (g_PsxUsePgxp)                                             \
+        {                                                             \
+            PGXP_CopyManualProjectionScreenOffset(&(poly)->x0, (center)); \
+            PGXP_CopyManualProjectionScreenOffset(&(poly)->x1, (center)); \
+            PGXP_CopyManualProjectionScreenOffset(&(poly)->x2, (center)); \
+            PGXP_CopyManualProjectionScreenOffset(&(poly)->x3, (center)); \
+        }                                                             \
+    } while (0)
+#define PGXP_TRACK_FLARE_QUAD_Q12(poly, center, scaleX, scaleY) do {   \
+        if (g_PsxUsePgxp)                                             \
+        {                                                             \
+            PGXP_CopyManualProjectionScreenOffsetQ12(&(poly)->x0, (center), (scaleX), (scaleY)); \
+            PGXP_CopyManualProjectionScreenOffsetQ12(&(poly)->x1, (center), (scaleX), (scaleY)); \
+            PGXP_CopyManualProjectionScreenOffsetQ12(&(poly)->x2, (center), (scaleX), (scaleY)); \
+            PGXP_CopyManualProjectionScreenOffsetQ12(&(poly)->x3, (center), (scaleX), (scaleY)); \
+        }                                                             \
+    } while (0)
 #else
 #define FL_SETRGB0 setRGB0
+#define PGXP_TRACK_FLARE_QUAD(poly, center) ((void)0)
+#define PGXP_TRACK_FLARE_QUAD_Q12(poly, center, scaleX, scaleY) ((void)0)
 #endif
 
 void func_8008D990(s32 arg0, q19_12 arg1, VECTOR3* arg2, s32 arg3, s32 arg4) // 0x8008D990
@@ -442,6 +462,7 @@ void func_8008D990(s32 arg0, q19_12 arg1, VECTOR3* arg2, s32 arg3, s32 arg4) // 
            temp_a2 + temp_a0, temp_a1_2 - temp_a0,
            temp_a2 - temp_a0, temp_a1_2 + temp_a0,
            temp_a2 + temp_a0, temp_a1_2 + temp_a0);
+    PGXP_TRACK_FLARE_QUAD(poly, arg2);
 
     if (arg0)
     {
@@ -478,6 +499,7 @@ void func_8008D990(s32 arg0, q19_12 arg1, VECTOR3* arg2, s32 arg3, s32 arg4) // 
            temp_v0_3 + 11, temp_v1_4 - 11,
            temp_v0_3 - 11, temp_v1_4 + 11,
            temp_v0_3 + 11, temp_v1_4 + 11);
+    PGXP_TRACK_FLARE_QUAD(poly, arg2);
 
     if (arg0)
     {
@@ -517,6 +539,7 @@ void func_8008D990(s32 arg0, q19_12 arg1, VECTOR3* arg2, s32 arg3, s32 arg4) // 
            temp_t0 + temp_a2_3, temp_a3_2 - temp_a2_3,
            temp_t0 - temp_a2_3, temp_a3_2 + temp_a2_3,
            temp_t0 + temp_a2_3, temp_a3_2 + temp_a2_3);
+    PGXP_TRACK_FLARE_QUAD(poly, arg2);
 
     AddPrim(temp_s7, poly);
     poly++;
@@ -563,6 +586,7 @@ void func_8008D990(s32 arg0, q19_12 arg1, VECTOR3* arg2, s32 arg3, s32 arg4) // 
                temp_a0_4 + FP_FROM(D_8002B2BC[2].vx * sinCurAngle + D_8002B2BC[2].vy * cosCurAngle, Q12_SHIFT),
                temp_v1_6 + FP_FROM(D_8002B2BC[3].vx * cosCurAngle - D_8002B2BC[3].vy * sinCurAngle, Q12_SHIFT),
                temp_a0_4 + FP_FROM(D_8002B2BC[3].vx * sinCurAngle + D_8002B2BC[3].vy * cosCurAngle, Q12_SHIFT));
+        PGXP_TRACK_FLARE_QUAD(poly, arg2);
 
         addPrim(temp_s7, poly);
         poly++;
@@ -592,6 +616,7 @@ void func_8008D990(s32 arg0, q19_12 arg1, VECTOR3* arg2, s32 arg3, s32 arg4) // 
            temp_a0_5 + temp_a1_5, temp_v1_8 - temp_a1_5,
            temp_a0_5 - temp_a1_5, temp_v1_8 + temp_a1_5,
            temp_a0_5 + temp_a1_5, temp_v1_8 + temp_a1_5);
+    PGXP_TRACK_FLARE_QUAD_Q12(poly, arg2, 0x333, 0x333);
 
     addPrim(temp_s7, poly);
     poly++;
@@ -615,6 +640,7 @@ void func_8008D990(s32 arg0, q19_12 arg1, VECTOR3* arg2, s32 arg3, s32 arg4) // 
            temp_v1_10 + Q12_MULT(temp_s2_2, 0x1C), temp_v0_11 - Q12_MULT(temp_s2_2, 0x1C),
            temp_v1_10 - Q12_MULT(temp_s2_2, 0x1C), temp_v0_11 + Q12_MULT(temp_s2_2, 0x1C),
            temp_v1_10 + Q12_MULT(temp_s2_2, 0x1C), temp_v0_11 + Q12_MULT(temp_s2_2, 0x1C));
+    PGXP_TRACK_FLARE_QUAD_Q12(poly, arg2, -0x4CC, -0x4CC);
 
     addPrim(temp_s7, poly);
     poly++;
@@ -637,6 +663,7 @@ void func_8008D990(s32 arg0, q19_12 arg1, VECTOR3* arg2, s32 arg3, s32 arg4) // 
            temp_v0_13 + 10, temp_v1_12 - 10,
            temp_v0_13 - 10, temp_v1_12 + 10,
            temp_v0_13 + 10, temp_v1_12 + 10);
+    PGXP_TRACK_FLARE_QUAD(poly, arg2);
 
     addPrim(temp_s7, poly);
     poly++;
@@ -773,10 +800,35 @@ void func_8008E794(VECTOR3* posXz, q3_12 angle, q19_12 posY) // 0x8008E794
     sp10    = sp20;
 
     sp30 = GsWSMATRIX;
+#ifdef SH_PC_PORT
+    PGXP_MatrixCopy(&sp30, &GsWSMATRIX);
+#endif
     ApplyMatrixLV(&GsWSMATRIX, &sp10, &sp30.t);
     sp30.t[0] += GsWSMATRIX.t[0];
     sp30.t[1] += GsWSMATRIX.t[1];
     sp30.t[2] += GsWSMATRIX.t[2];
+#ifdef SH_PC_PORT
+    {
+        double exactRot[9];
+        double exactBaseT[3];
+        double exactT[3];
+        if (PGXP_MatrixLookup(&GsWSMATRIX, exactRot) &&
+            PGXP_MatrixLookupTranslation(&GsWSMATRIX, exactBaseT))
+        {
+            const double x = (double)posXz->vx / 16.0;
+            const double y = ((double)posY * 2.0 - (double)posXz->vy) / 16.0;
+            const double z = (double)posXz->vz / 16.0;
+            exactT[0] = exactBaseT[0] + exactRot[0] * x + exactRot[1] * y + exactRot[2] * z;
+            exactT[1] = exactBaseT[1] + exactRot[3] * x + exactRot[4] * y + exactRot[5] * z;
+            exactT[2] = exactBaseT[2] + exactRot[6] * x + exactRot[7] * y + exactRot[8] * z;
+            PGXP_MatrixRegisterTranslation(&sp30, exactT);
+        }
+        else
+        {
+            PGXP_MatrixInvalidateTranslation(&sp30);
+        }
+    }
+#endif
     SetTransMatrix(&sp30);
 
     if ((RotTransPers(&svec0, &sp20, &sp50, &sp50) * 4) >= 128)
@@ -821,6 +873,15 @@ void func_8008E794(VECTOR3* posXz, q3_12 angle, q19_12 posY) // 0x8008E794
         poly->y2    = ((u32)sp20.vx >> 16) + 48;
         poly->x3    = sp20.vx + 24;
         poly->y3    = ((u32)sp20.vx >> 16) + 48;
+#ifdef SH_PC_PORT
+        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+        {
+            Shadow_CopyScreenOffset(&poly->x0, &sp20);
+            Shadow_CopyScreenOffset(&poly->x1, &sp20);
+            Shadow_CopyScreenOffset(&poly->x2, &sp20);
+            Shadow_CopyScreenOffset(&poly->x3, &sp20);
+        }
+#endif
 
         AddPrim(g_OrderingTable0[g_ActiveBufferIdx].org + 641, poly);
         GsOUT_PACKET_P = poly + 1;
@@ -875,6 +936,9 @@ void func_8008EA68(SVECTOR* arg0, VECTOR3* posXz, q19_12 posY) // 0x8008EA68
     sp50.coord.t[0] = Q12_TO_Q8(posXz->vx);
     sp50.coord.t[1] = Q12_TO_Q8(posY);
     sp50.coord.t[2] = Q12_TO_Q8(posXz->vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&sp50.coord, posXz->vx, posY, posXz->vz);
+#endif
 
     Vw_CoordToViewSpaceMatrix(&sp50, &spA0);
     SetRotMatrix(&spA0);
@@ -955,6 +1019,21 @@ void func_8008EA68(SVECTOR* arg0, VECTOR3* posXz, q19_12 posY) // 0x8008EA68
 
         *(s32*)&poly->g4[1].x2 = *(s32*)&poly->g4[0].x2;
         *(s32*)&poly->g4[1].x3 = *(s32*)&poly->g4[0].x3;
+#ifdef SH_PC_PORT
+        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+        {
+            Shadow_Copy(&poly->g3[1].x0, &spC8);
+            Shadow_Copy(&poly->g3[0].x0, &spC8);
+            Shadow_Copy(&poly->g3[1].x1, &poly->g4[0].x0);
+            Shadow_Copy(&poly->g3[0].x1, &poly->g4[0].x0);
+            Shadow_Copy(&poly->g4[1].x0, &poly->g4[0].x0);
+            Shadow_Copy(&poly->g3[1].x2, &poly->g4[0].x1);
+            Shadow_Copy(&poly->g3[0].x2, &poly->g4[0].x1);
+            Shadow_Copy(&poly->g4[1].x1, &poly->g4[0].x1);
+            Shadow_Copy(&poly->g4[1].x2, &poly->g4[0].x2);
+            Shadow_Copy(&poly->g4[1].x3, &poly->g4[0].x3);
+        }
+#endif
 
         AddPrim(spD0, &poly->g4[0]);
         AddPrim(spD0, &poly->g3[0]);

--- a/src/maps/characters/air_screamer.c
+++ b/src/maps/characters/air_screamer.c
@@ -12794,6 +12794,12 @@ void sharedFunc_800D7560_0_s01(s_SubCharacter* airScreamer)
     mat->t[0] = Q12_TO_Q8(airScreamer->position.vx + offsetX);
     mat->t[1] = Q12_TO_Q8(airScreamer->position.vy);
     mat->t[2] = Q12_TO_Q8(airScreamer->position.vz + offsetZ);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(mat,
+                                      airScreamer->position.vx + offsetX,
+                                      airScreamer->position.vy,
+                                      airScreamer->position.vz + offsetZ);
+#endif
 }
 
 void sharedFunc_800D76A0_0_s01(s_SubCharacter* airScreamer)

--- a/src/maps/characters/alessa.c
+++ b/src/maps/characters/alessa.c
@@ -79,6 +79,9 @@ void Alessa_MovementUpdate(s_SubCharacter* alessa, GsCOORDINATE2* boneCoords)
     boneCoords[AlessaBone_Root].coord.t[0] = Q12_TO_Q8(alessa->position.vx);
     boneCoords[AlessaBone_Root].coord.t[1] = Q12_TO_Q8(alessa->position.vy);
     boneCoords[AlessaBone_Root].coord.t[2] = Q12_TO_Q8(alessa->position.vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&boneCoords[AlessaBone_Root].coord, alessa->position.vx, alessa->position.vy, alessa->position.vz);
+#endif
 }
 
 /** Addresses

--- a/src/maps/characters/bloody_incubator.c
+++ b/src/maps/characters/bloody_incubator.c
@@ -50,6 +50,9 @@ void func_800D3740(s_SubCharacter* bloodyIncubator, GsCOORDINATE2* boneCoords) /
     boneCoords[BloodyIncubatorBone_Root].coord.t[0] = Q12_TO_Q8(bloodyIncubator->position.vx);
     boneCoords[BloodyIncubatorBone_Root].coord.t[1] = Q12_TO_Q8(bloodyIncubator->position.vy);
     boneCoords[BloodyIncubatorBone_Root].coord.t[2] = Q12_TO_Q8(bloodyIncubator->position.vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&boneCoords[BloodyIncubatorBone_Root].coord, bloodyIncubator->position.vx, bloodyIncubator->position.vy, bloodyIncubator->position.vz);
+#endif
 }
 
 void func_800D38D8(s_SubCharacter* bloodyIncubator, GsCOORDINATE2* boneCoords) // 0x800D38D8

--- a/src/maps/characters/bloody_lisa.c
+++ b/src/maps/characters/bloody_lisa.c
@@ -76,6 +76,9 @@ void BloodyLisa_MovementUpdate(s_SubCharacter* bloodyLisa, GsCOORDINATE2* boneCo
     boneCoords[0].coord.t[0] = Q12_TO_Q8(bloodyLisa->position.vx);
     boneCoords[0].coord.t[1] = Q12_TO_Q8(bloodyLisa->position.vy);
     boneCoords[0].coord.t[2] = Q12_TO_Q8(bloodyLisa->position.vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&boneCoords[0].coord, bloodyLisa->position.vx, bloodyLisa->position.vy, bloodyLisa->position.vz);
+#endif
 }
 
  /** Addresses

--- a/src/maps/characters/cheryl.c
+++ b/src/maps/characters/cheryl.c
@@ -107,6 +107,9 @@ void Cheryl_MovementUpdate(s_SubCharacter* cheryl, GsCOORDINATE2* coords) // 0x8
     coords->coord.t[0] = Q12_TO_Q8(cheryl->position.vx);
     coords->coord.t[1] = Q12_TO_Q8(cheryl->position.vy);
     coords->coord.t[2] = Q12_TO_Q8(cheryl->position.vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&coords->coord, cheryl->position.vx, cheryl->position.vy, cheryl->position.vz);
+#endif
 }
 
 void Cheryl_ControlUpdate(s_SubCharacter* cheryl, GsCOORDINATE2* coords) // 0x800D8310

--- a/src/maps/characters/cybil.c
+++ b/src/maps/characters/cybil.c
@@ -107,6 +107,9 @@ void Ai_Cybil_MovementUpdate(s_SubCharacter* chara, GsCOORDINATE2* coords)
     coords->coord.t[0] = Q12_TO_Q8(chara->position.vx);
     coords->coord.t[1] = Q12_TO_Q8(chara->position.vy);
     coords->coord.t[2] = Q12_TO_Q8(chara->position.vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&coords->coord, chara->position.vx, chara->position.vy, chara->position.vz);
+#endif
 }
 
 /** Addresses

--- a/src/maps/characters/dahlia.c
+++ b/src/maps/characters/dahlia.c
@@ -100,6 +100,9 @@ void Dahlia_MovementUpdate(s_SubCharacter* dahlia, GsCOORDINATE2* boneCoords)
     boneCoords[0].coord.t[0] = Q12_TO_Q8(dahlia->position.vx);
     boneCoords[0].coord.t[1] = Q12_TO_Q8(dahlia->position.vy);
     boneCoords[0].coord.t[2] = Q12_TO_Q8(dahlia->position.vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&boneCoords[0].coord, dahlia->position.vx, dahlia->position.vy, dahlia->position.vz);
+#endif
 }
 
 /** Addresses

--- a/src/maps/characters/ghost_child_alessa.c
+++ b/src/maps/characters/ghost_child_alessa.c
@@ -70,6 +70,9 @@ void GhostChildAlessa_MovementUpdate(s_SubCharacter* ghostAlessa, GsCOORDINATE2*
     boneCoords[GhostChildAlessaBone_Root].coord.t[0] = Q12_TO_Q8(ghostAlessa->position.vx);
     boneCoords[GhostChildAlessaBone_Root].coord.t[1] = Q12_TO_Q8(ghostAlessa->position.vy);
     boneCoords[GhostChildAlessaBone_Root].coord.t[2] = Q12_TO_Q8(ghostAlessa->position.vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&boneCoords[GhostChildAlessaBone_Root].coord, ghostAlessa->position.vx, ghostAlessa->position.vy, ghostAlessa->position.vz);
+#endif
 }
 
 /** Addresses

--- a/src/maps/characters/ghost_doctor.c
+++ b/src/maps/characters/ghost_doctor.c
@@ -26,6 +26,9 @@ void Character_CoordTransformUpdate(s_SubCharacter* ghostDoc, GsCOORDINATE2* bon
     boneCoords[GhostDoctorBone_Root].coord.t[0] = Q12_TO_Q8(ghostDoc->position.vx);
     boneCoords[GhostDoctorBone_Root].coord.t[1] = Q12_TO_Q8(ghostDoc->position.vy);
     boneCoords[GhostDoctorBone_Root].coord.t[2] = Q12_TO_Q8(ghostDoc->position.vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&boneCoords[GhostDoctorBone_Root].coord, ghostDoc->position.vx, ghostDoc->position.vy, ghostDoc->position.vz);
+#endif
 }
 
 void GhostDoctor_Init(s_SubCharacter* ghostDoc) // 0x800D8BE0

--- a/src/maps/characters/incubator.c
+++ b/src/maps/characters/incubator.c
@@ -50,6 +50,9 @@ void func_800D3C80(s_SubCharacter* incubator, GsCOORDINATE2* boneCoords)
     boneCoords[IncubatorBone_Root].coord.t[0] = Q12_TO_Q8(incubator->position.vx);
     boneCoords[IncubatorBone_Root].coord.t[1] = Q12_TO_Q8(incubator->position.vy);
     boneCoords[IncubatorBone_Root].coord.t[2] = Q12_TO_Q8(incubator->position.vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&boneCoords[IncubatorBone_Root].coord, incubator->position.vx, incubator->position.vy, incubator->position.vz);
+#endif
 }
 
 void func_800D3E18(s_SubCharacter* incubator, GsCOORDINATE2* boneCoords) // 0x800D3E18

--- a/src/maps/characters/kaufmann.c
+++ b/src/maps/characters/kaufmann.c
@@ -82,6 +82,9 @@ void Kaufmann_MovementUpdate(s_SubCharacter* kaufmann, GsCOORDINATE2* boneCoords
     boneCoords[0].coord.t[0] = Q12_TO_Q8(kaufmann->position.vx);
     boneCoords[0].coord.t[1] = Q12_TO_Q8(kaufmann->position.vy);
     boneCoords[0].coord.t[2] = Q12_TO_Q8(kaufmann->position.vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&boneCoords[0].coord, kaufmann->position.vx, kaufmann->position.vy, kaufmann->position.vz);
+#endif
 }
 
 /** Addresses

--- a/src/maps/characters/lisa.c
+++ b/src/maps/characters/lisa.c
@@ -84,6 +84,9 @@ void Lisa_MovementUpdate(s_SubCharacter* lisa, GsCOORDINATE2* boneCoords)
     boneCoords[LisaBone_Root].coord.t[0] = Q12_TO_Q8(lisa->position.vx);
     boneCoords[LisaBone_Root].coord.t[1] = Q12_TO_Q8(lisa->position.vy);
     boneCoords[LisaBone_Root].coord.t[2] = Q12_TO_Q8(lisa->position.vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&boneCoords[LisaBone_Root].coord, lisa->position.vx, lisa->position.vy, lisa->position.vz);
+#endif
 }
 
 /** Addresses

--- a/src/maps/characters/monster_cybil.c
+++ b/src/maps/characters/monster_cybil.c
@@ -835,6 +835,9 @@ void func_800D99E4(s_SubCharacter* monsterCybil, s_Model* modelUpper, s_AnmHeade
     boneCoords[MonsterCybilBone_Root].coord.t[0] = Q12_TO_Q8(monsterCybil->position.vx);
     boneCoords[MonsterCybilBone_Root].coord.t[1] = Q12_TO_Q8(monsterCybil->position.vy);
     boneCoords[MonsterCybilBone_Root].coord.t[2] = Q12_TO_Q8(monsterCybil->position.vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&boneCoords[MonsterCybilBone_Root].coord, monsterCybil->position.vx, monsterCybil->position.vy, monsterCybil->position.vz);
+#endif
 
     // TODO: Cybil has same skeleton structure as Harry? Check and make separate mask macros just for Cybil.
     anmHdr->activeBones = HARRY_LOWER_BODY_BONE_MASK;

--- a/src/maps/characters/player.c
+++ b/src/maps/characters/player.c
@@ -220,6 +220,12 @@ void sharedFunc_800D1C38_0_s00(s_SubCharacter* chara, s_PlayerExtra* extra, GsCO
     coords->coord.t[0] = Q12_TO_Q8(chara->position.vx);
     coords->coord.t[1] = Q12_TO_Q8(chara->position.vy);
     coords->coord.t[2] = Q12_TO_Q8(chara->position.vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&coords->coord,
+                                      chara->position.vx,
+                                      chara->position.vy,
+                                      chara->position.vz);
+#endif
 }
 
 void sharedFunc_800D209C_0_s00(void)
@@ -1264,4 +1270,3 @@ void sharedFunc_800D2EF4_0_s00(void)
 {
     g_SysWork.playerCombat.weaponAttack = sharedData_800DD59C_0_s00;
 }
-

--- a/src/maps/characters/twinfeeler.c
+++ b/src/maps/characters/twinfeeler.c
@@ -229,6 +229,16 @@ void func_800D0D6C(MATRIX* worldMat, SVECTOR* pos, q19_12 rotY) // 0x800D0D6C
     worldMat->t[0] = Q12_TO_Q8(ptr->x_0) + pos->vx;
     worldMat->t[1] = Q12_TO_Q8(Q12(0.0f));
     worldMat->t[2] = Q12_TO_Q8(ptr->z_4) + pos->vz;
+#ifdef SH_PC_PORT
+    {
+        const double exactTranslation[3] = {
+            (double)ptr->x_0 / 16.0 + (double)pos->vx,
+            0.0,
+            (double)ptr->z_4 / 16.0 + (double)pos->vz
+        };
+        PGXP_MatrixRegisterTranslation(worldMat, exactTranslation);
+    }
+#endif
 }
 
 void func_800D0DE4(SVECTOR* out, VECTOR* in, q19_12 headingAngle, q19_12 dist) // 0x800D0DE4
@@ -807,6 +817,15 @@ void func_800D1D3C(GsOT_TAG* tag, SVECTOR3* arg1, MATRIX* worldMat, s32 arg3) //
     *(s32*)&poly2->x1 = *(s32*)&sp50;
     *(s32*)&poly2->x2 = *(s32*)&sp54;
     *(s32*)&poly2->x3 = *(s32*)&sp58;
+#ifdef SH_PC_PORT
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_Copy(&poly2->x0, &sp4C);
+        Shadow_Copy(&poly2->x1, &sp50);
+        Shadow_Copy(&poly2->x2, &sp54);
+        Shadow_Copy(&poly2->x3, &sp58);
+    }
+#endif
     *(s32*)&poly2->r0 = *(s32*)&sp48;
 
     setPolyFT4(poly2);
@@ -829,6 +848,15 @@ void func_800D1D3C(GsOT_TAG* tag, SVECTOR3* arg1, MATRIX* worldMat, s32 arg3) //
     *(s32*)&poly->x1 = *(s32*)&sp50;
     *(s32*)&poly->x2 = *(s32*)&sp54;
     *(s32*)&poly->x3 = *(s32*)&sp58;
+#ifdef SH_PC_PORT
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_Copy(&poly->x0, &sp4C);
+        Shadow_Copy(&poly->x1, &sp50);
+        Shadow_Copy(&poly->x2, &sp54);
+        Shadow_Copy(&poly->x3, &sp58);
+    }
+#endif
     *(s32*)&poly->r0 = *(s32*)&sp48;
 
     setPolyFT4(poly);

--- a/src/maps/map1_s03/unk_draw_800CDCE0.c
+++ b/src/maps/map1_s03/unk_draw_800CDCE0.c
@@ -159,6 +159,12 @@ bool func_800CE164(POLY_FT4** poly, s32 idx) // 0x800CE164
                            Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].field_0.vx_0) - (u16)scratch->field_0.field_0.vx,
                            Q12_TO_Q8((s32)sharedData_800DFB7C_0_s00[idx].vy_8) - scratch->field_0.field_0.vy,
                            Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].field_4.vz_4) - scratch->field_0.field_0.vz);
+#ifdef SH_PC_PORT
+    PGXP_VectorRegisterQ12(&scratch->field_12C,
+                           sharedData_800DFB7C_0_s00[idx].field_0.vx_0 - Q8_TO_Q12((s16)scratch->field_0.field_0.vx),
+                           (s32)sharedData_800DFB7C_0_s00[idx].vy_8 - Q8_TO_Q12(scratch->field_0.field_0.vy),
+                           sharedData_800DFB7C_0_s00[idx].field_4.vz_4 - Q8_TO_Q12(scratch->field_0.field_0.vz));
+#endif
 
     gte_ldv0(&scratch->field_12C);
     gte_rtps();
@@ -194,6 +200,15 @@ bool func_800CE164(POLY_FT4** poly, s32 idx) // 0x800CE164
     setXY1Fast(*poly, (u16)scratch->field_134.vx + var_a2, scratch->field_134.vy - var_a1);
     setXY2Fast(*poly, (u16)scratch->field_134.vx - var_a2, scratch->field_134.vy);
     setXY3Fast(*poly, (u16)scratch->field_134.vx + var_a2, scratch->field_134.vy);
+#ifdef SH_PC_PORT
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_CopyScreenOffset(&(*poly)->x0, &scratch->field_134.vx);
+        Shadow_CopyScreenOffset(&(*poly)->x1, &scratch->field_134.vx);
+        Shadow_CopyScreenOffset(&(*poly)->x2, &scratch->field_134.vx);
+        Shadow_CopyScreenOffset(&(*poly)->x3, &scratch->field_134.vx);
+    }
+#endif
 
     *(u32*)&(*poly)->u0 = ((sharedData_800DFB7C_0_s00[idx].field_C.s_1.field_2 << 13) + 0xE0000);
     *(u32*)&(*poly)->u1 = ((sharedData_800DFB7C_0_s00[idx].field_C.s_1.field_2 << 13) + 0x2D003F);

--- a/src/maps/map4_s03/map4_s03.c
+++ b/src/maps/map4_s03/map4_s03.c
@@ -254,6 +254,16 @@ void func_800D0D6C(MATRIX* out, SVECTOR* pos, q19_12 rotY) // 0x800D0D6C
     out->t[0] = Q12_TO_Q8(ptr->x_0) + pos->vx;
     out->t[1] = Q12_TO_Q8(Q12(0.0f));
     out->t[2] = Q12_TO_Q8(ptr->z_4) + pos->vz;
+#ifdef SH_PC_PORT
+    {
+        const double exactTranslation[3] = {
+            (double)ptr->x_0 / 16.0 + (double)pos->vx,
+            0.0,
+            (double)ptr->z_4 / 16.0 + (double)pos->vz
+        };
+        PGXP_MatrixRegisterTranslation(out, exactTranslation);
+    }
+#endif
 }
 
 void func_800D0DE4(SVECTOR* out, VECTOR* in, q19_12 headingAngle, q19_12 dist) // 0x800D0DE4
@@ -452,6 +462,15 @@ void func_800D0FD4(s32* ord, void* arg1, u8* arg2, MATRIX* arg3, s32 arg4, s32 a
             {
                 x = (j - 1) * w + xbase;
                 setXYWH(poly, x, y, w, h);
+#ifdef SH_PC_PORT
+                if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+                {
+                    Shadow_CopyScreenOffset(&poly->x0, &sxy);
+                    Shadow_CopyScreenOffset(&poly->x1, &sxy);
+                    Shadow_CopyScreenOffset(&poly->x2, &sxy);
+                    Shadow_CopyScreenOffset(&poly->x3, &sxy);
+                }
+#endif
 
                 *(s32*)&poly->r0 = col0;
                 *(s32*)&poly->r1 = col1;
@@ -855,6 +874,15 @@ void func_800D1D3C(GsOT_TAG* tag, SVECTOR3* arg1, MATRIX* arg2, s32 arg3) // 0x8
     *(s32*)&poly2->x1 = *(s32*)&sp50;
     *(s32*)&poly2->x2 = *(s32*)&sp54;
     *(s32*)&poly2->x3 = *(s32*)&sp58;
+#ifdef SH_PC_PORT
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_Copy(&poly2->x0, &sp4C);
+        Shadow_Copy(&poly2->x1, &sp50);
+        Shadow_Copy(&poly2->x2, &sp54);
+        Shadow_Copy(&poly2->x3, &sp58);
+    }
+#endif
     *(s32*)&poly2->r0 = *(s32*)&sp48;
 
     setPolyFT4(poly2);
@@ -887,6 +915,15 @@ void func_800D1D3C(GsOT_TAG* tag, SVECTOR3* arg1, MATRIX* arg2, s32 arg3) // 0x8
     *(s32*)&poly->x1 = *(s32*)&sp50;
     *(s32*)&poly->x2 = *(s32*)&sp54;
     *(s32*)&poly->x3 = *(s32*)&sp58;
+#ifdef SH_PC_PORT
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_Copy(&poly->x0, &sp4C);
+        Shadow_Copy(&poly->x1, &sp50);
+        Shadow_Copy(&poly->x2, &sp54);
+        Shadow_Copy(&poly->x3, &sp58);
+    }
+#endif
     *(s32*)&poly->r0 = *(s32*)&sp48;
 
     setPolyFT4(poly);
@@ -4717,6 +4754,15 @@ void func_800D88C8(s_800E06A0* arg0, u8 arg1) // 0x800D88C8
 
             *(s32*)&poly->x2 = *(s32*)&sp10[2];
             *(s32*)&poly->x3 = *(s32*)&sp10[3];
+#ifdef SH_PC_PORT
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_Copy(&poly->x0, &sp10[0]);
+                Shadow_Copy(&poly->x1, &sp10[1]);
+                Shadow_Copy(&poly->x2, &sp10[2]);
+                Shadow_Copy(&poly->x3, &sp10[3]);
+            }
+#endif
 
             setUV4(poly,
                    temp_s6, temp_s4,
@@ -4747,6 +4793,15 @@ void func_800D88C8(s_800E06A0* arg0, u8 arg1) // 0x800D88C8
         sp30[2][2].field_0 = sp10[3];
         sp30[2][2].field_8 = spB0;
         sp30[2][2].field_A = var_t0;
+#ifdef SH_PC_PORT
+        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+        {
+            Shadow_Copy(&sp30[0][0].field_0, &sp10[0]);
+            Shadow_Copy(&sp30[0][2].field_0, &sp10[1]);
+            Shadow_Copy(&sp30[2][0].field_0, &sp10[2]);
+            Shadow_Copy(&sp30[2][2].field_0, &sp10[3]);
+        }
+#endif
 
         sp30[0][1].field_0.vx = (sp30[0][0].field_0.vx + sp30[0][2].field_0.vx) >> 1;
         sp30[0][1].field_0.vy = (sp30[0][0].field_0.vy + sp30[0][2].field_0.vy) >> 1;
@@ -4777,6 +4832,19 @@ void func_800D88C8(s_800E06A0* arg0, u8 arg1) // 0x800D88C8
         sp30[1][1].field_0.vz = (sp30[1][0].field_0.vz + sp30[1][2].field_0.vz) >> 1;
         sp30[1][1].field_8    = (sp30[1][0].field_8 + sp30[1][2].field_8) >> 1;
         sp30[1][1].field_A    = (sp30[1][0].field_A + sp30[1][2].field_A) >> 1;
+#ifdef SH_PC_PORT
+        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+        {
+            /* Mirror the integer 3x3 subdivision in the precise shadow.  The
+             * centre is derived from the already-interpolated side midpoints,
+             * preserving the same bilinear construction as the original. */
+            Shadow_InterpolateScreenOffset(&sp30[0][1].field_0, &sp30[0][0].field_0, &sp30[0][2].field_0, Q12(0.5f));
+            Shadow_InterpolateScreenOffset(&sp30[1][0].field_0, &sp30[0][0].field_0, &sp30[2][0].field_0, Q12(0.5f));
+            Shadow_InterpolateScreenOffset(&sp30[1][2].field_0, &sp30[0][2].field_0, &sp30[2][2].field_0, Q12(0.5f));
+            Shadow_InterpolateScreenOffset(&sp30[2][1].field_0, &sp30[2][0].field_0, &sp30[2][2].field_0, Q12(0.5f));
+            Shadow_InterpolateScreenOffset(&sp30[1][1].field_0, &sp30[1][0].field_0, &sp30[1][2].field_0, Q12(0.5f));
+        }
+#endif
 
         for (j = 0; j < 2; j++)
         {
@@ -4797,6 +4865,15 @@ void func_800D88C8(s_800E06A0* arg0, u8 arg1) // 0x800D88C8
                     *(s32*)&poly2->x1 = *(s32*)&sp30[j][k + 1];
                     *(s32*)&poly2->x2 = *(s32*)&sp30[j + 1][k];
                     *(s32*)&poly2->x3 = *(s32*)&sp30[j + 1][k + 1];
+#ifdef SH_PC_PORT
+                    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+                    {
+                        Shadow_Copy(&poly2->x0, &sp30[j][k].field_0);
+                        Shadow_Copy(&poly2->x1, &sp30[j][k + 1].field_0);
+                        Shadow_Copy(&poly2->x2, &sp30[j + 1][k].field_0);
+                        Shadow_Copy(&poly2->x3, &sp30[j + 1][k + 1].field_0);
+                    }
+#endif
 
                     setUV4(poly2,
                            sp30[j][k].field_8, sp30[j][k].field_A,

--- a/src/maps/map5_s00/map5_s00.c
+++ b/src/maps/map5_s00/map5_s00.c
@@ -107,6 +107,9 @@ void func_800D5D90(void) // 0x800D5D90
             sp10.vx = Q12_TO_Q4(ptr->field_0.vx);
             sp10.vy = Q12_TO_Q4(ptr->field_0.vy);
             sp10.vz = Q12_TO_Q4(ptr->field_0.vz);
+#ifdef SH_PC_PORT
+            PGXP_VectorRegisterFixed(&sp10, ptr->field_0.vx, ptr->field_0.vy, ptr->field_0.vz, 8);
+#endif
 
             RotTransPers(&sp10, &sp18[0], &sp18[1], &sp20);
             func_800D5CC4(sp18[0].vx, sp18[0].vy, ptr->field_30);
@@ -230,6 +233,16 @@ void func_800D5EE8(void) // 0x800D5EE8
                 *(s32*)&poly->r2 = col3;
                 *(s32*)&poly->r3 = col2;
             }
+
+#ifdef SH_PC_PORT
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_CopyScreenOffset(&poly->x0, &ptr->field_D84);
+                Shadow_CopyScreenOffset(&poly->x1, &ptr->field_D84);
+                Shadow_CopyScreenOffset(&poly->x2, &ptr->field_D84);
+                Shadow_CopyScreenOffset(&poly->x3, &ptr->field_D84);
+            }
+#endif
 
             setPolyG4(poly);
             poly->code = (float)sp18; // @hack

--- a/src/maps/map5_s00/unk_draw_800CB0D8.c
+++ b/src/maps/map5_s00/unk_draw_800CB0D8.c
@@ -103,6 +103,20 @@ bool func_800CB25C(POLY_FT4** poly, s32 idx) // 0x800CB25C
                                Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].vy_8) - ptr->field_0.field_0.vy,
                                Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].field_4.vz_4 - ptr->field_15C) - ptr->field_0.field_0.vz);
 
+#ifdef SH_PC_PORT
+        {
+            const s32 x = sharedData_800DFB7C_0_s00[idx].field_0.vx_0;
+            const s32 y = sharedData_800DFB7C_0_s00[idx].vy_8;
+            const s32 z = sharedData_800DFB7C_0_s00[idx].field_4.vz_4;
+            const s32 bx = Q8_TO_Q12((s16)ptr->field_0.field_0.vx);
+            const s32 by = Q8_TO_Q12(ptr->field_0.field_0.vy);
+            const s32 bz = Q8_TO_Q12(ptr->field_0.field_0.vz);
+            PGXP_VectorRegisterQ12(&ptr->field_12C[0], x - ptr->field_15C - bx, y - by, z + ptr->field_15C - bz);
+            PGXP_VectorRegisterQ12(&ptr->field_12C[1], x + ptr->field_15C - bx, y - by, z + ptr->field_15C - bz);
+            PGXP_VectorRegisterQ12(&ptr->field_12C[2], x - ptr->field_15C - bx, y - by, z - ptr->field_15C - bz);
+        }
+#endif
+
         gte_ldv3c(&ptr->field_12C);
         gte_rtpt();
         gte_stsxy3_g3(*poly);
@@ -112,6 +126,12 @@ bool func_800CB25C(POLY_FT4** poly, s32 idx) // 0x800CB25C
                                Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].field_0.vx_0 + ptr->field_15C) - (u16)ptr->field_0.field_0.vx,
                                Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].vy_8) - ptr->field_0.field_0.vy,
                                Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].field_4.vz_4 - ptr->field_15C) - ptr->field_0.field_0.vz);
+#ifdef SH_PC_PORT
+        PGXP_VectorRegisterQ12(&ptr->field_12C[0],
+                               sharedData_800DFB7C_0_s00[idx].field_0.vx_0 + ptr->field_15C - Q8_TO_Q12((s16)ptr->field_0.field_0.vx),
+                               sharedData_800DFB7C_0_s00[idx].vy_8 - Q8_TO_Q12(ptr->field_0.field_0.vy),
+                               sharedData_800DFB7C_0_s00[idx].field_4.vz_4 - ptr->field_15C - Q8_TO_Q12(ptr->field_0.field_0.vz));
+#endif
 
         gte_ldv0(&ptr->field_12C);
         gte_rtps();
@@ -131,6 +151,10 @@ bool func_800CB25C(POLY_FT4** poly, s32 idx) // 0x800CB25C
         }
 
         *(s32*)&(*poly)->x3 = *(s32*)&ptr->field_144;
+        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+        {
+            Shadow_Copy(&(*poly)->x3, &ptr->field_144);
+        }
         setSemiTrans(*poly, 1);
 
         if (CLAMP_LOW(Q12_MULT_PRECISE(Q12(1.0f) - sharedData_800DFB7C_0_s00[idx].field_C.s_2.field_0, 32), 0) < 16)
@@ -205,6 +229,13 @@ bool func_800CB25C(POLY_FT4** poly, s32 idx) // 0x800CB25C
                        sp10[i][j + 1].vx, sp10[i][j + 1].vy,
                        sp10[i + 1][j].vx, sp10[i + 1][j].vy,
                        sp10[i + 1][j + 1].vx, sp10[i + 1][j + 1].vy);
+                if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+                {
+                    Shadow_Copy(&(*poly)->x0, &sp10[i][j]);
+                    Shadow_Copy(&(*poly)->x1, &sp10[i][j + 1]);
+                    Shadow_Copy(&(*poly)->x2, &sp10[i + 1][j]);
+                    Shadow_Copy(&(*poly)->x3, &sp10[i + 1][j + 1]);
+                }
 
                 setSemiTrans(*poly, 1);
 

--- a/src/maps/map6_s00/map6_s00.c
+++ b/src/maps/map6_s00/map6_s00.c
@@ -771,6 +771,13 @@ void func_800EC4B4(s32 arg0) // 0x800EC4B4
                         setXY1Fast(ptr->field_0, ptr2->field_0[i][j].vx, ptr2->field_0[i][j].vy);
                         setXY2Fast(ptr->field_0, ptr2->field_0[i + 1][j + 1].vx, ptr2->field_0[i + 1][j + 1].vy);
                         setXY3Fast(ptr->field_0, ptr2->field_0[i + 1][j].vx, ptr2->field_0[i + 1][j].vy);
+                        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+                        {
+                            Shadow_Copy(&ptr->field_0->x0, &ptr2->field_0[i][j + 1]);
+                            Shadow_Copy(&ptr->field_0->x1, &ptr2->field_0[i][j]);
+                            Shadow_Copy(&ptr->field_0->x2, &ptr2->field_0[i + 1][j + 1]);
+                            Shadow_Copy(&ptr->field_0->x3, &ptr2->field_0[i + 1][j]);
+                        }
 
                         setRGB0Fast(ptr->field_0, ptr->field_74[1].r, ptr->field_74[1].g, ptr->field_74[1].b);
                         setRGB1Fast(ptr->field_0, ptr->field_74[0].r, ptr->field_74[0].g, ptr->field_74[0].b);
@@ -788,6 +795,13 @@ void func_800EC4B4(s32 arg0) // 0x800EC4B4
                         setXY1Fast(ptr->field_0, ptr2->field_0[i][j + 1].vx, ptr2->field_0[i][j + 1].vy);
                         setXY2Fast(ptr->field_0, ptr2->field_0[i + 1][j].vx, ptr2->field_0[i + 1][j].vy);
                         setXY3Fast(ptr->field_0, ptr2->field_0[i + 1][j + 1].vx, ptr2->field_0[i + 1][j + 1].vy);
+                        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+                        {
+                            Shadow_Copy(&ptr->field_0->x0, &ptr2->field_0[i][j]);
+                            Shadow_Copy(&ptr->field_0->x1, &ptr2->field_0[i][j + 1]);
+                            Shadow_Copy(&ptr->field_0->x2, &ptr2->field_0[i + 1][j]);
+                            Shadow_Copy(&ptr->field_0->x3, &ptr2->field_0[i + 1][j + 1]);
+                        }
 
                         setRGB0Fast(ptr->field_0, ptr->field_74[0].r, ptr->field_74[0].g, ptr->field_74[0].b);
                         setRGB1Fast(ptr->field_0, ptr->field_74[1].r, ptr->field_74[1].g, ptr->field_74[1].b);

--- a/src/maps/map6_s02/map6_s02_2.c
+++ b/src/maps/map6_s02/map6_s02_2.c
@@ -1705,6 +1705,13 @@ void func_800D2364(void) // 0x800D2364
                 setXY1Fast(poly, var_t2_2->field_0[i + 1][j].vx, var_t2_2->field_0[i + 1][j].vy);
                 setXY2Fast(poly, var_t2_2->field_0[i][j + 1].vx, var_t2_2->field_0[i][j + 1].vy);
                 setXY3Fast(poly, var_t2_2->field_0[i + 1][j + 1].vx, var_t2_2->field_0[i + 1][j + 1].vy);
+                if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+                {
+                    Shadow_Copy(&poly->x0, &var_t2_2->field_0[i][j]);
+                    Shadow_Copy(&poly->x1, &var_t2_2->field_0[i + 1][j]);
+                    Shadow_Copy(&poly->x2, &var_t2_2->field_0[i][j + 1]);
+                    Shadow_Copy(&poly->x3, &var_t2_2->field_0[i + 1][j + 1]);
+                }
 
                 setRGB0(poly, ptr->field_6C[i][j], ptr->field_6C[i][j], ptr->field_6C[i][j]);
                 setRGB1(poly, ptr->field_6C[i + 1][j], ptr->field_6C[i + 1][j], ptr->field_6C[i + 1][j]);

--- a/src/maps/map6_s04/map6_s04_2.c
+++ b/src/maps/map6_s04/map6_s04_2.c
@@ -805,6 +805,13 @@ PACKET* func_800DF6C4(GsOT_TAG* ot, PACKET* packet, MATRIX* mat) // 0x800DF6C4
             *(s32*)&poly->x1 = *(s32*)&sp48[1];
             *(s32*)&poly->x2 = *(s32*)&sp48[2];
             *(s32*)&poly->x3 = *(s32*)&sp48[3];
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_Copy(&poly->x0, &sp48[0]);
+                Shadow_Copy(&poly->x1, &sp48[1]);
+                Shadow_Copy(&poly->x2, &sp48[2]);
+                Shadow_Copy(&poly->x3, &sp48[3]);
+            }
 
             *(s32*)&poly->r0 = temp_s0;
             *(s32*)&poly->r1 = var_s6;
@@ -999,6 +1006,13 @@ void* func_800DFD3C(GsOT_TAG* ot, PACKET* packet, MATRIX* mat, s32 arg3, s32 arg
             *(s32*)&poly->x1 = *(s32*)&sp48[1];
             *(s32*)&poly->x2 = *(s32*)&sp48[2];
             *(s32*)&poly->x3 = *(s32*)&sp48[3];
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_Copy(&poly->x0, &sp48[0]);
+                Shadow_Copy(&poly->x1, &sp48[1]);
+                Shadow_Copy(&poly->x2, &sp48[2]);
+                Shadow_Copy(&poly->x3, &sp48[3]);
+            }
 
             *(s32*)&poly->r0 = temp_s0;
             *(s32*)&poly->r1 = var_s6;
@@ -1298,6 +1312,9 @@ void func_800E068C(void) // 0x800E068C
             sp10.vx = Q12_TO_Q8(ptr->vec_4.vx);
             sp10.vy = Q12_TO_Q8(ptr->vec_4.vy);
             sp10.vz = Q12_TO_Q8(ptr->vec_4.vz);
+#ifdef SH_PC_PORT
+            PGXP_VectorRegisterQ12(&sp10, ptr->vec_4.vx, ptr->vec_4.vy, ptr->vec_4.vz);
+#endif
 
             RotTransPers(&sp10, &sp18[0], &sp18[1], &sp20);
             func_800E05C8(sp18[0].vx, sp18[0].vy, ptr->field_28);

--- a/src/maps/map7_s03/map7_s03_2.c
+++ b/src/maps/map7_s03/map7_s03_2.c
@@ -196,6 +196,9 @@ void func_800D60E4(void) // 0x800D60E4
             sp10.vx = Q12_TO_Q4(ptr->field_0.vx);
             sp10.vy = Q12_TO_Q4(ptr->field_0.vy);
             sp10.vz = Q12_TO_Q4(ptr->field_0.vz);
+#ifdef SH_PC_PORT
+            PGXP_VectorRegisterFixed(&sp10, ptr->field_0.vx, ptr->field_0.vy, ptr->field_0.vz, 8);
+#endif
 
             RotTransPers(&sp10, &sp18[0], &sp18[1], &sp20);
             func_800D600C(sp18[0].vx, sp18[0].vy, ptr->field_30);
@@ -315,6 +318,16 @@ void func_800D625C(void) // 0x800D625C
                 *(s32*)&poly->r2 = col3;
                 *(s32*)&poly->r3 = col2;
             }
+
+#ifdef SH_PC_PORT
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_CopyScreenOffset(&poly->x0, &ptr->field_A50);
+                Shadow_CopyScreenOffset(&poly->x1, &ptr->field_A50);
+                Shadow_CopyScreenOffset(&poly->x2, &ptr->field_A50);
+                Shadow_CopyScreenOffset(&poly->x3, &ptr->field_A50);
+            }
+#endif
 
             setPolyG4(poly);
             poly->code = (float)sp18; // @hack
@@ -583,6 +596,9 @@ void func_800D6ADC(void) // 0x800D6ADC
         sp10.vx = Q12_TO_Q4(curPtr->field_0.vx);
         sp10.vy = Q12_TO_Q4(curPtr->field_0.vy);
         sp10.vz = Q12_TO_Q4(curPtr->field_0.vz);
+#ifdef SH_PC_PORT
+        PGXP_VectorRegisterFixed(&sp10, curPtr->field_0.vx, curPtr->field_0.vy, curPtr->field_0.vz, 8);
+#endif
 
         RotTransPers(&sp10, &sp18[0], &sp18[1], &sp20);
         func_800D6A10(sp18[0].vx, sp18[0].vy, curPtr->field_30);
@@ -694,6 +710,16 @@ void func_800D6C0C(void) // 0x800D6C0C
                 *(s32*)&poly->r2 = col3;
                 *(s32*)&poly->r3 = col2;
             }
+
+#ifdef SH_PC_PORT
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_CopyScreenOffset(&poly->x0, &ptr->field_9FC);
+                Shadow_CopyScreenOffset(&poly->x1, &ptr->field_9FC);
+                Shadow_CopyScreenOffset(&poly->x2, &ptr->field_9FC);
+                Shadow_CopyScreenOffset(&poly->x3, &ptr->field_9FC);
+            }
+#endif
 
             setPolyG4(poly);
             poly->code = (float)sp18; // @hack
@@ -964,6 +990,9 @@ void func_800D75D0(void) // 0x800D75D0
                 sp10.vx = Q12_TO_Q8(ptr->field_0.vx);
                 sp10.vy = Q12_TO_Q8(ptr->field_0.vy);
                 sp10.vz = Q12_TO_Q8(ptr->field_0.vz);
+#ifdef SH_PC_PORT
+                PGXP_VectorRegisterQ12(&sp10, ptr->field_0.vx, ptr->field_0.vy, ptr->field_0.vz);
+#endif
 
                 RotTransPers(&sp10, &sp18[0], &sp18[1], &sp20);
                 func_800D74F4(sp18[0].vx, sp18[0].vy, ptr->field_28);
@@ -1317,6 +1346,13 @@ void func_800D7F20(u8* arg0) // 0x800D7F20
     GsOUT_PACKET_P = arg0;
 }
 
+#ifdef SH_PC_PORT
+/* Stable packed destination for the GTE projection used by the screen-built
+ * boss effects below. Keeping the GTE store at this address lets every derived
+ * corner inherit the center's precise sub-pixel XY and perspective W. */
+static DVECTOR s_func_800D822C_TrackedScreenCenter;
+#endif
+
 void func_800D7F2C(GsOT_TAG* ot, s32 arg1, q19_12 angle, q19_12 dist0, q19_12 dist1, s16 x1, s16 y1, s32 arg7) // 0x800D7F2C
 {
     q19_12   sp14;
@@ -1375,6 +1411,16 @@ void func_800D7F2C(GsOT_TAG* ot, s32 arg1, q19_12 angle, q19_12 dist0, q19_12 di
 
         setXY4(poly, x0, y0, x1, y1, x2, y2, x3, y3);
 
+#ifdef SH_PC_PORT
+        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+        {
+            Shadow_CopyScreenOffset(&poly->x0, &s_func_800D822C_TrackedScreenCenter);
+            Shadow_CopyScreenOffset(&poly->x1, &s_func_800D822C_TrackedScreenCenter);
+            Shadow_CopyScreenOffset(&poly->x2, &s_func_800D822C_TrackedScreenCenter);
+            Shadow_CopyScreenOffset(&poly->x3, &s_func_800D822C_TrackedScreenCenter);
+        }
+#endif
+
         addPrim(ot, poly);
         poly++;
     }
@@ -1390,11 +1436,17 @@ s32 func_800D822C(SVECTOR* worldPos, s16* outScreenX, s16* outScreenY) // 0x800D
     s16     screenX;
     s16     screenY;
 
+#ifdef SH_PC_PORT
+    depth = RotTransPers(worldPos, &s_func_800D822C_TrackedScreenCenter, &screenCoords[1], &screenCoords[1]);
+    screenX = s_func_800D822C_TrackedScreenCenter.vx;
+    screenY = s_func_800D822C_TrackedScreenCenter.vy;
+#else
     depth = RotTransPers(worldPos, &screenCoords[0], &screenCoords[1], &screenCoords[1]);
-    scale = (ReadGeomScreen() * 200) / (depth + 1);
-
     screenX = screenCoords[0].vx;
     screenY = screenCoords[0].vy;
+#endif
+
+    scale = (ReadGeomScreen() * 200) / (depth + 1);
 
     *outScreenX = screenX;
     *outScreenY = screenY;
@@ -1485,6 +1537,16 @@ void func_800D8454(s32* arg0, s32 x, s32 y, s32 s) // 0x800D8454
             poly->y1 = FP_FROM(y0 + h0, Q12_SHIFT);
             poly->y2 = FP_FROM(y1, Q12_SHIFT);
             poly->y3 = FP_FROM(y1 + h1, Q12_SHIFT);
+
+#ifdef SH_PC_PORT
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_CopyScreenOffset(&poly->x0, &s_func_800D822C_TrackedScreenCenter);
+                Shadow_CopyScreenOffset(&poly->x1, &s_func_800D822C_TrackedScreenCenter);
+                Shadow_CopyScreenOffset(&poly->x2, &s_func_800D822C_TrackedScreenCenter);
+                Shadow_CopyScreenOffset(&poly->x3, &s_func_800D822C_TrackedScreenCenter);
+            }
+#endif
 
             col0 = func_800D8438(FP_FROM(var_s1, Q12_SHIFT));
             col1 = func_800D8438(FP_FROM(var_s1 - sp34, Q12_SHIFT));
@@ -1636,6 +1698,12 @@ void func_800D8954(s_800F3D48* arg0, s_800F3D48_0_0* arg1) // 0x800D8954
     sp10.vx = Q12_TO_Q8(arg0->field_4.field_18.vx);
     sp10.vy = Q12_TO_Q8(arg0->field_4.field_18.vy);
     sp10.vz = Q12_TO_Q8(arg0->field_4.field_18.vz);
+#ifdef SH_PC_PORT
+    PGXP_VectorRegisterQ12(&sp10,
+                           arg0->field_4.field_18.vx,
+                           arg0->field_4.field_18.vy,
+                           arg0->field_4.field_18.vz);
+#endif
 
     temp_s1 = RotTransPers(&sp10, &sp18[0], &sp18[1], &sp20);
 
@@ -1688,6 +1756,15 @@ void func_800D8954(s_800F3D48* arg0, s_800F3D48_0_0* arg1) // 0x800D8954
            x0 + offsetX, y0,
            x0, y0 + offsetY,
            x0 + offsetX, y0 + offsetY);
+#ifdef SH_PC_PORT
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_CopyScreenOffset(&poly->x0, &sp18[0]);
+        Shadow_CopyScreenOffset(&poly->x1, &sp18[0]);
+        Shadow_CopyScreenOffset(&poly->x2, &sp18[0]);
+        Shadow_CopyScreenOffset(&poly->x3, &sp18[0]);
+    }
+#endif
 
     setUV4(poly, arg1->field_0, arg1->field_2, arg1->field_0 + arg1->field_4, arg1->field_2,
            arg1->field_0, arg1->field_2 + arg1->field_6, arg1->field_0 + arg1->field_4, arg1->field_2 + arg1->field_6);
@@ -1808,6 +1885,15 @@ void func_800D8D90(s_800F3D48* arg0, s_800F3D48_0_0* arg1) // 0x800D8D90
     *(s32*)&poly->x1 = *(s32*)&sp50[1];
     *(s32*)&poly->x2 = *(s32*)&sp50[2];
     *(s32*)&poly->x3 = *(s32*)&sp50[3];
+#ifdef SH_PC_PORT
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_Copy(&poly->x0, &sp50[0]);
+        Shadow_Copy(&poly->x1, &sp50[1]);
+        Shadow_Copy(&poly->x2, &sp50[2]);
+        Shadow_Copy(&poly->x3, &sp50[3]);
+    }
+#endif
 
     setUV4(poly, arg1->field_0, arg1->field_2, arg1->field_0 + arg1->field_4, arg1->field_2,
            arg1->field_0, arg1->field_2 + arg1->field_6, arg1->field_0 + arg1->field_4, arg1->field_2 + arg1->field_6);
@@ -2865,6 +2951,9 @@ void func_800DADE0(s_func_800DAD54* arg0, s_800F3D48_0_0* arg1) // 0x800DADE0
     sp10.vx = Q12_TO_Q8(arg0->field_C.vx);
     sp10.vy = Q12_TO_Q8(arg0->field_C.vy);
     sp10.vz = Q12_TO_Q8(arg0->field_C.vz);
+#ifdef SH_PC_PORT
+    PGXP_VectorRegisterQ12(&sp10, arg0->field_C.vx, arg0->field_C.vy, arg0->field_C.vz);
+#endif
 
     temp_s1 = RotTransPers(&sp10, &sp18[0], &sp18[1], &flags);
 
@@ -2916,6 +3005,15 @@ void func_800DADE0(s_func_800DAD54* arg0, s_800F3D48_0_0* arg1) // 0x800DADE0
            x0 + offsetX, y0,
            x0, y0 + offsetY,
            x0 + offsetX, y0 + offsetY);
+#ifdef SH_PC_PORT
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_CopyScreenOffset(&poly->x0, &sp18[0]);
+        Shadow_CopyScreenOffset(&poly->x1, &sp18[0]);
+        Shadow_CopyScreenOffset(&poly->x2, &sp18[0]);
+        Shadow_CopyScreenOffset(&poly->x3, &sp18[0]);
+    }
+#endif
 
     setUV4(poly, arg1->field_0, arg1->field_2, arg1->field_0 + arg1->field_4, arg1->field_2,
            arg1->field_0, arg1->field_2 + arg1->field_6, arg1->field_0 + arg1->field_4, arg1->field_2 + arg1->field_6);
@@ -3430,11 +3528,25 @@ void func_800DBD94(s_800F3DAC* arg0, GsOT_TAG* ot) // 0x800DBD94
         {
             var_s6 = sp30;
             var_s5 = sp34;
+#ifdef SH_PC_PORT
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_Copy(&var_s6, &sp30);
+                Shadow_Copy(&var_s5, &sp34);
+            }
+#endif
         }
         else
         {
             var_s6 = sp34;
             var_s5 = sp30;
+#ifdef SH_PC_PORT
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_Copy(&var_s6, &sp34);
+                Shadow_Copy(&var_s5, &sp30);
+            }
+#endif
         }
 
         sp10.vx = Q12_TO_Q8(Q12_MULT_PRECISE(Math_Sin(angle2), dist));
@@ -3508,6 +3620,15 @@ void func_800DBD94(s_800F3DAC* arg0, GsOT_TAG* ot) // 0x800DBD94
         *(s32*)&poly->x1 = var_s5;
         *(s32*)&poly->x2 = sp30;
         *(s32*)&poly->x3 = sp34;
+#ifdef SH_PC_PORT
+        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+        {
+            Shadow_Copy(&poly->x0, &var_s6);
+            Shadow_Copy(&poly->x1, &var_s5);
+            Shadow_Copy(&poly->x2, &sp30);
+            Shadow_Copy(&poly->x3, &sp34);
+        }
+#endif
 
         var_a0  = (i & 1) ? 0 : 0x7F;
         temp_v1 = 0x40;
@@ -3954,6 +4075,12 @@ void func_800DCD94(MATRIX* mat, VECTOR3* pos) // 0x800DCD94
     mat->t[0] = Q12_TO_Q8(pos->vx - D_800F48A8.positionX);
     mat->t[1] = Q12_TO_Q8(pos->vy);
     mat->t[2] = Q12_TO_Q8(pos->vz - D_800F48A8.positionZ);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(mat,
+                                      pos->vx - D_800F48A8.positionX,
+                                      pos->vy,
+                                      pos->vz - D_800F48A8.positionZ);
+#endif
 }
 
 void func_800DCDDC(s_800F3DAC* arg0, const VECTOR3* arg1, const VECTOR3* arg2) // 0x800DCDDC

--- a/src/maps/map7_s03/map7_s03_3.c
+++ b/src/maps/map7_s03/map7_s03_3.c
@@ -876,6 +876,15 @@ void func_800E2968(s_800F4B40_118* arg0, s32 colCount, s32 rowCount, DVECTOR* ar
 
             temp_s1->x_0 = temp_s5 + Q12_MULT(temp_s3, Math_Cos(angle2));
             temp_s1->y_2 = temp_s4 + Q12_MULT(temp_s3, Math_Sin(angle2));
+#ifdef SH_PC_PORT
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                /* The ribbon centre is a screen-space interpolation of two
+                 * projected world endpoints; retain their fractional motion,
+                 * then apply this column's radial integer offset. */
+                Shadow_InterpolateScreenOffset(&temp_s1->x_0, arg3, arg4, temp_lo);
+            }
+#endif
         }
     }
 }
@@ -908,6 +917,15 @@ void func_800E2C28(s_800F4B40_118* arg0, s32 colCount, s32 rowCount, s32 zDepth,
             *(s32*)&poly->r2 = *(s32*)&colData[colCount + 0].color_4;
             *(s32*)&poly->x3 = *(s32*)&colData[colCount + 1].x_0;
             *(s32*)&poly->r3 = *(s32*)&colData[colCount + 1].color_4;
+#ifdef SH_PC_PORT
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_Copy(&poly->x0, &colData[0].x_0);
+                Shadow_Copy(&poly->x1, &colData[1].x_0);
+                Shadow_Copy(&poly->x2, &colData[colCount + 0].x_0);
+                Shadow_Copy(&poly->x3, &colData[colCount + 1].x_0);
+            }
+#endif
 
             setPolyG4(poly);
             setSemiTrans(poly, 1);
@@ -4181,4 +4199,3 @@ void func_800E9C28(void) // 0x800E9C28
             break;
     }
 }
-

--- a/src/maps/particle.c
+++ b/src/maps/particle.c
@@ -898,6 +898,12 @@ bool Particle_Update(s_Particle* partHead)
     g_SysWork.coord_22A8.coord.t[1] = Q8(0.0f);
     g_SysWork.coord_22A8.coord.t[0] = Q12_TO_Q8(g_Particle_Position.vx);
     g_SysWork.coord_22A8.coord.t[2] = Q12_TO_Q8(g_Particle_Position.vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&g_SysWork.coord_22A8.coord,
+                                      g_Particle_Position.vx,
+                                      Q12(0.0f),
+                                      g_Particle_Position.vz);
+#endif
 
     g_SysWork.coord_22A8.flg = false;
     Vw_CoordToWorldAndViewMatrices(&g_SysWork.coord_22A8, &worldMat, &viewMat);
@@ -1591,6 +1597,9 @@ s32 func_800CC8FC(VECTOR3* arg0, s32* arg1, s_func_800CC8FC* arg2) // 0x800CC8FC
         offset0.vx += Q12_TO_Q8(g_ParticleVectors0.vector_0.vx - g_SysWork.playerWork.player.position.vx);
         offset0.vy += Q12_TO_Q8(g_ParticleVectors0.vector_0.vy - g_SysWork.playerWork.player.position.vy);
         offset0.vz += Q12_TO_Q8(g_ParticleVectors0.vector_0.vz - g_SysWork.playerWork.player.position.vz);
+#ifdef SH_PC_PORT
+        PGXP_VectorRegisterQ12(&offset0, unkPos->vx, unkPos->vy, unkPos->vz);
+#endif
 
         gte_ldv0(&offset0);
         gte_rtps();
@@ -2052,6 +2061,9 @@ void func_800CD8E8(s32 arg0, s32 arg1, s_800E330C* arg2) // 0x800CD8E8
     pos.vx = Q12_TO_Q8(arg2->field_0.vx);
     pos.vy = Q12_TO_Q8(arg2->field_0.vy);
     pos.vz = Q12_TO_Q8(arg2->field_0.vz);
+#ifdef SH_PC_PORT
+    PGXP_VectorRegisterQ12(&pos, arg2->field_0.vx, arg2->field_0.vy, arg2->field_0.vz);
+#endif
 
     gte_ldv0(&pos);
     gte_rtps();
@@ -2089,6 +2101,14 @@ void func_800CD8E8(s32 arg0, s32 arg1, s_800E330C* arg2) // 0x800CD8E8
         poly->x2 = poly->x3 = poly->x0 + temp_a1;
         poly->y2            = poly->y0;
         poly->y1 = poly->y3 = poly->y0 + temp_a1;
+#ifdef SH_PC_PORT
+        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+        {
+            Shadow_CopyScreenOffset(&poly->x1, &poly->x0);
+            Shadow_CopyScreenOffset(&poly->x2, &poly->x0);
+            Shadow_CopyScreenOffset(&poly->x3, &poly->x0);
+        }
+#endif
 
         addPrim(&g_OrderingTable0[g_ActiveBufferIdx].org[depth], poly);
 
@@ -2244,6 +2264,9 @@ void func_800CE02C(s32 arg0, s32 arg1, s_800E34FC* pos, s32 mapId) // 0x800CE02C
     posQ8.vx = Q12_TO_Q8(pos->field_0.vx);
     posQ8.vy = Q12_TO_Q8(pos->field_0.vy);
     posQ8.vz = Q12_TO_Q8(pos->field_0.vz);
+#ifdef SH_PC_PORT
+    PGXP_VectorRegisterQ12(&posQ8, pos->field_0.vx, pos->field_0.vy, pos->field_0.vz);
+#endif
 
     gte_ldv0(&posQ8);
     gte_rtps();
@@ -2282,6 +2305,14 @@ void func_800CE02C(s32 arg0, s32 arg1, s_800E34FC* pos, s32 mapId) // 0x800CE02C
         poly->x2 = poly->x3 = poly->x0 + var_a1;
         poly->y2            = poly->y0;
         poly->y1 = poly->y3 = poly->y0 + var_a1;
+#ifdef SH_PC_PORT
+        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+        {
+            Shadow_CopyScreenOffset(&poly->x1, &poly->x0);
+            Shadow_CopyScreenOffset(&poly->x2, &poly->x0);
+            Shadow_CopyScreenOffset(&poly->x3, &poly->x0);
+        }
+#endif
 
         addPrim(&g_OrderingTable0[g_ActiveBufferIdx].org[depth], poly);
 
@@ -2639,6 +2670,9 @@ void Particle_SnowDraw(s_Particle* part)
             particlePosQ8.vx = Q12_TO_Q8(particlePos.vx);
             particlePosQ8.vy = Q12_TO_Q8(localPart->position0_0.vy);
             particlePosQ8.vz = Q12_TO_Q8(particlePos.vz);
+#ifdef SH_PC_PORT
+            PGXP_VectorRegisterQ12(&particlePosQ8, particlePos.vx, localPart->position0_0.vy, particlePos.vz);
+#endif
         }
         else
 #endif
@@ -2646,6 +2680,12 @@ void Particle_SnowDraw(s_Particle* part)
             particlePosQ8.vx = Q12_TO_Q8(localPart->position0_0.vx);
             particlePosQ8.vy = Q12_TO_Q8(localPart->position0_0.vy);
             particlePosQ8.vz = Q12_TO_Q8(localPart->position0_0.vz);
+#ifdef SH_PC_PORT
+            PGXP_VectorRegisterQ12(&particlePosQ8,
+                                   localPart->position0_0.vx,
+                                   localPart->position0_0.vy,
+                                   localPart->position0_0.vz);
+#endif
         }
 
         gte_ldv0(&particlePosQ8);
@@ -2760,6 +2800,13 @@ void Particle_SnowDraw(s_Particle* part)
                 polyFt3->x2   = polyFt3->x0 + 3;
                 polyFt3->y1   = polyFt3->y0 + 3;
             }
+#ifdef SH_PC_PORT
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_CopyScreenOffset(&polyFt3->x1, &polyFt3->x0);
+                Shadow_CopyScreenOffset(&polyFt3->x2, &polyFt3->x0);
+            }
+#endif
 
 #if defined(MAP1_S00) || defined(MAP6_S00)
             addPrim(&g_OrderingTable0[g_ActiveBufferIdx].org[zScreenStart], polyFt3);
@@ -2800,6 +2847,9 @@ void Particle_RainDraw(s_Particle* part, s32 arg1)
     SVECTOR     sp28;
     SVECTOR     sp30;
     SVECTOR     sp38;
+#ifdef SH_PC_PORT
+    s32         endpoint1Screen;
+#endif
     s32         depth;
     s32         colorComp;
     s32         test;
@@ -2850,6 +2900,9 @@ void Particle_RainDraw(s_Particle* part, s32 arg1)
             sp20.vx = Q12_TO_Q8(localPart->position1_C.vx);
             sp20.vy = Q12_TO_Q8(localPart->position1_C.vy);
             sp20.vz = Q12_TO_Q8(localPart->position1_C.vz);
+#ifdef SH_PC_PORT
+            PGXP_VectorRegisterQ12(&sp20, localPart->position1_C.vx, localPart->position1_C.vy, localPart->position1_C.vz);
+#endif
 
             gte_ldv0(&sp20);
             gte_rtps();
@@ -2857,6 +2910,9 @@ void Particle_RainDraw(s_Particle* part, s32 arg1)
             sp28.vx = Q12_TO_Q8(localPart->position0_0.vx);
             sp28.vy = Q12_TO_Q8(localPart->position0_0.vy);
             sp28.vz = Q12_TO_Q8(localPart->position0_0.vz);
+#ifdef SH_PC_PORT
+            PGXP_VectorRegisterQ12(&sp28, localPart->position0_0.vx, localPart->position0_0.vy, localPart->position0_0.vz);
+#endif
 
             gte_stsxy(&poly->x0);
             gte_stszotz(&depth);
@@ -2943,6 +2999,13 @@ void Particle_RainDraw(s_Particle* part, s32 arg1)
 
                 poly->x3 = poly->x1 + 1;
                 poly->y3 = poly->y1;
+#ifdef SH_PC_PORT
+                if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+                {
+                    Shadow_CopyScreenOffset(&poly->x2, &poly->x0);
+                    Shadow_CopyScreenOffset(&poly->x3, &poly->x1);
+                }
+#endif
 
                 addPrim(&g_OrderingTable0[g_ActiveBufferIdx].org[depth], poly);
                 GsOUT_PACKET_P = (PACKET*)(poly + 1);
@@ -2991,6 +3054,12 @@ void Particle_RainDraw(s_Particle* part, s32 arg1)
             sp20.vx = Q12_TO_Q8(localPart->position0_0.vx - colorComp);
             sp20.vy = Q12_TO_Q8(localPart->position0_0.vy);
             sp20.vz = Q12_TO_Q8(localPart->position0_0.vz - colorComp);
+#ifdef SH_PC_PORT
+            PGXP_VectorRegisterQ12(&sp20,
+                                   localPart->position0_0.vx - colorComp,
+                                   localPart->position0_0.vy,
+                                   localPart->position0_0.vz - colorComp);
+#endif
 
             gte_ldv0(&sp20);
             gte_rtps();
@@ -3009,6 +3078,20 @@ void Particle_RainDraw(s_Particle* part, s32 arg1)
             sp38.vx = sp30.vx;
             sp38.vy = sp20.vy;
             sp38.vz = sp28.vz;
+#ifdef SH_PC_PORT
+            PGXP_VectorRegisterQ12(&sp28,
+                                   localPart->position0_0.vx - colorComp,
+                                   localPart->position0_0.vy,
+                                   localPart->position0_0.vz + colorComp);
+            PGXP_VectorRegisterQ12(&sp30,
+                                   localPart->position0_0.vx + colorComp,
+                                   localPart->position0_0.vy,
+                                   localPart->position0_0.vz - colorComp);
+            PGXP_VectorRegisterQ12(&sp38,
+                                   localPart->position0_0.vx + colorComp,
+                                   localPart->position0_0.vy,
+                                   localPart->position0_0.vz + colorComp);
+#endif
 
             gte_ldv3(&sp28, &sp30, &sp38);
             gte_rtpt();
@@ -3148,6 +3231,9 @@ void Particle_RainDraw(s_Particle* part, s32 arg1)
     sp20.vx = Q12_TO_Q8(localPart->position1_C.vx);
     sp20.vy = Q12_TO_Q8(localPart->position1_C.vy);
     sp20.vz = Q12_TO_Q8(localPart->position1_C.vz);
+#ifdef SH_PC_PORT
+    PGXP_VectorRegisterQ12(&sp20, localPart->position1_C.vx, localPart->position1_C.vy, localPart->position1_C.vz);
+#endif
 
     gte_ldv0(&sp20);
     gte_rtps();
@@ -3155,6 +3241,9 @@ void Particle_RainDraw(s_Particle* part, s32 arg1)
     sp28.vx = Q12_TO_Q8(localPart->position0_0.vx);
     sp28.vy = Q12_TO_Q8(localPart->position0_0.vy);
     sp28.vz = Q12_TO_Q8(localPart->position0_0.vz);
+#ifdef SH_PC_PORT
+    PGXP_VectorRegisterQ12(&sp28, localPart->position0_0.vx, localPart->position0_0.vy, localPart->position0_0.vz);
+#endif
 
     gte_stsxy(&poly->x0);
     gte_stszotz(&depth);
@@ -3164,6 +3253,13 @@ void Particle_RainDraw(s_Particle* part, s32 arg1)
     depth = depth >> 1;
 
     gte_stsxy(&poly->x1);
+#ifdef SH_PC_PORT
+    endpoint1Screen = *(s32*)&poly->x1;
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_Copy(&endpoint1Screen, &poly->x1);
+    }
+#endif
 
     if (depth > 32 && depth < ORDERING_TABLE_SIZE - 1)
     {
@@ -3196,6 +3292,14 @@ void Particle_RainDraw(s_Particle* part, s32 arg1)
         poly->x3 = poly->x1 + 1;
         poly->y1++;
         poly->y3 = poly->y1;
+#ifdef SH_PC_PORT
+        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+        {
+            Shadow_CopyScreenOffset(&poly->x2, &poly->x0);
+            Shadow_CopyScreenOffset(&poly->x1, &endpoint1Screen);
+            Shadow_CopyScreenOffset(&poly->x3, &endpoint1Screen);
+        }
+#endif
 
         addPrim(&g_OrderingTable0[g_ActiveBufferIdx].org[depth], poly);
         GsOUT_PACKET_P = (PACKET*)(poly + 1);
@@ -4178,6 +4282,12 @@ void Particle_HyperBlasterBeamDraw(VECTOR3* vec0, q3_12* rotX, q3_12* rotY)
     g_SysWork.coord_22F8.coord.t[0] = Q12_TO_Q8(g_SysWork.playerWork.player.position.vx);
     g_SysWork.coord_22F8.coord.t[1] = Q12_TO_Q8(g_SysWork.playerWork.player.position.vy);
     g_SysWork.coord_22F8.coord.t[2] = Q12_TO_Q8(g_SysWork.playerWork.player.position.vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&g_SysWork.coord_22F8.coord,
+                                      g_SysWork.playerWork.player.position.vx,
+                                      g_SysWork.playerWork.player.position.vy,
+                                      g_SysWork.playerWork.player.position.vz);
+#endif
 
     Vw_CoordToWorldAndViewMatrices(&g_SysWork.coord_22F8, &worldMat, &viewMat);
 
@@ -4209,6 +4319,12 @@ void Particle_HyperBlasterBeamDraw(VECTOR3* vec0, q3_12* rotX, q3_12* rotY)
         startRelPos.vx = Q12_TO_Q8(beamStart.vx - g_SysWork.playerWork.player.position.vx);
         startRelPos.vy = Q12_TO_Q8(beamStart.vy - g_SysWork.playerWork.player.position.vy);
         startRelPos.vz = Q12_TO_Q8(beamStart.vz - g_SysWork.playerWork.player.position.vz);
+#ifdef SH_PC_PORT
+        PGXP_VectorRegisterQ12(&startRelPos,
+                               beamStart.vx - g_SysWork.playerWork.player.position.vx,
+                               beamStart.vy - g_SysWork.playerWork.player.position.vy,
+                               beamStart.vz - g_SysWork.playerWork.player.position.vz);
+#endif
         gte_ldv0(&startRelPos);
         gte_rtps();
 
@@ -4220,6 +4336,12 @@ void Particle_HyperBlasterBeamDraw(VECTOR3* vec0, q3_12* rotX, q3_12* rotY)
         endRelPos.vx  = Q12_TO_Q8(beamOffset.vx - g_SysWork.playerWork.player.position.vx);
         endRelPos.vy  = Q12_TO_Q8(beamOffset.vy - g_SysWork.playerWork.player.position.vy);
         endRelPos.vz  = Q12_TO_Q8(beamOffset.vz - g_SysWork.playerWork.player.position.vz);
+#ifdef SH_PC_PORT
+        PGXP_VectorRegisterQ12(&endRelPos,
+                               beamOffset.vx - g_SysWork.playerWork.player.position.vx,
+                               beamOffset.vy - g_SysWork.playerWork.player.position.vy,
+                               beamOffset.vz - g_SysWork.playerWork.player.position.vz);
+#endif
 
         gte_stsxy(&polyGt4->x0);
         gte_stszotz(&zScreenStart);
@@ -4234,6 +4356,12 @@ void Particle_HyperBlasterBeamDraw(VECTOR3* vec0, q3_12* rotX, q3_12* rotY)
             endRelPos.vx = Q12_TO_Q8(trace.target.vx - g_SysWork.playerWork.player.position.vx);
             endRelPos.vy = Q12_TO_Q8(trace.target.vy - g_SysWork.playerWork.player.position.vy);
             endRelPos.vz = Q12_TO_Q8(trace.target.vz - g_SysWork.playerWork.player.position.vz);
+#ifdef SH_PC_PORT
+            PGXP_VectorRegisterQ12(&endRelPos,
+                                   trace.target.vx - g_SysWork.playerWork.player.position.vx,
+                                   trace.target.vy - g_SysWork.playerWork.player.position.vy,
+                                   trace.target.vz - g_SysWork.playerWork.player.position.vz);
+#endif
         }
 
         gte_ldv0(&endRelPos);
@@ -4241,6 +4369,12 @@ void Particle_HyperBlasterBeamDraw(VECTOR3* vec0, q3_12* rotX, q3_12* rotY)
         gte_stsxy(&polyGt4->x1);
         polyFt3Pos.vx = polyGt4->x1;
         polyFt3Pos.vy = polyGt4->y1;
+#ifdef SH_PC_PORT
+        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+        {
+            Shadow_Copy(&polyFt3Pos.vx, &polyGt4->x1);
+        }
+#endif
 
         gte_stszotz(&zScreenEnd);
         zScreenEnd = zScreenEnd >> 1;
@@ -4323,6 +4457,13 @@ void Particle_HyperBlasterBeamDraw(VECTOR3* vec0, q3_12* rotX, q3_12* rotY)
 
             polyGt4->y2 = polyGt4->y0 + 1;
             polyGt4->y3 = polyGt4->y1 + 1;
+#ifdef SH_PC_PORT
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_CopyScreenOffset(&polyGt4->x2, &polyGt4->x0);
+                Shadow_CopyScreenOffset(&polyGt4->x3, &polyGt4->x1);
+            }
+#endif
 
             addPrim(&ot->org[zScreenStart], polyGt4);
             GsOUT_PACKET_P = (PACKET*)&polyGt4[1];
@@ -4348,6 +4489,14 @@ void Particle_HyperBlasterBeamDraw(VECTOR3* vec0, q3_12* rotX, q3_12* rotY)
             polyFt3->y2 = polyFt3->y0;
             polyFt3->x2 = polyFt3->x0 + 4;
             polyFt3->y1 = polyFt3->y0 + 4;
+#ifdef SH_PC_PORT
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_CopyScreenOffset(&polyFt3->x0, &polyFt3Pos.vx);
+                Shadow_CopyScreenOffset(&polyFt3->x1, &polyFt3Pos.vx);
+                Shadow_CopyScreenOffset(&polyFt3->x2, &polyFt3Pos.vx);
+            }
+#endif
 
             switch (Game_HyperBlasterBeamColorGet())
             {
@@ -4399,6 +4548,12 @@ void Particle_BeamDraw(const VECTOR3* from, const VECTOR3* to)
     g_SysWork.coord_22F8.coord.t[0] = Q12_TO_Q8(g_SysWork.playerWork.player.position.vx);
     g_SysWork.coord_22F8.coord.t[1] = Q12_TO_Q8(g_SysWork.playerWork.player.position.vy);
     g_SysWork.coord_22F8.coord.t[2] = Q12_TO_Q8(g_SysWork.playerWork.player.position.vz);
+#ifdef SH_PC_PORT
+    PGXP_MatrixRegisterTranslationQ12(&g_SysWork.coord_22F8.coord,
+                                      g_SysWork.playerWork.player.position.vx,
+                                      g_SysWork.playerWork.player.position.vy,
+                                      g_SysWork.playerWork.player.position.vz);
+#endif
 
     Vw_CoordToWorldAndViewMatrices(&g_SysWork.coord_22F8, &worldMat, &viewMat);
     gte_SetRotMatrix(&viewMat);
@@ -4409,6 +4564,12 @@ void Particle_BeamDraw(const VECTOR3* from, const VECTOR3* to)
     fromDelta.vx = Q12_TO_Q8(from->vx - g_SysWork.playerWork.player.position.vx);
     fromDelta.vy = Q12_TO_Q8(from->vy - g_SysWork.playerWork.player.position.vy);
     fromDelta.vz = Q12_TO_Q8(from->vz - g_SysWork.playerWork.player.position.vz);
+#ifdef SH_PC_PORT
+    PGXP_VectorRegisterQ12(&fromDelta,
+                           from->vx - g_SysWork.playerWork.player.position.vx,
+                           from->vy - g_SysWork.playerWork.player.position.vy,
+                           from->vz - g_SysWork.playerWork.player.position.vz);
+#endif
 
     gte_ldv0(&fromDelta);
     gte_rtps();
@@ -4416,6 +4577,12 @@ void Particle_BeamDraw(const VECTOR3* from, const VECTOR3* to)
     toDelta.vx = Q12_TO_Q8(to->vx - g_SysWork.playerWork.player.position.vx);
     toDelta.vy = Q12_TO_Q8(to->vy - g_SysWork.playerWork.player.position.vy);
     toDelta.vz = Q12_TO_Q8(to->vz - g_SysWork.playerWork.player.position.vz);
+#ifdef SH_PC_PORT
+    PGXP_VectorRegisterQ12(&toDelta,
+                           to->vx - g_SysWork.playerWork.player.position.vx,
+                           to->vy - g_SysWork.playerWork.player.position.vy,
+                           to->vz - g_SysWork.playerWork.player.position.vz);
+#endif
 
     gte_stsxy(&prim->x0);
     gte_stszotz(&depth);
@@ -4510,6 +4677,13 @@ void Particle_BeamDraw(const VECTOR3* from, const VECTOR3* to)
 
     prim->y2 = prim->y0 + 1;
     prim->y3 = prim->y1 + 1;
+#ifdef SH_PC_PORT
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_CopyScreenOffset(&prim->x2, &prim->x0);
+        Shadow_CopyScreenOffset(&prim->x3, &prim->x1);
+    }
+#endif
 
     addPrim(&ot->org[depth], prim);
 

--- a/src/maps/particle.c
+++ b/src/maps/particle.c
@@ -2516,6 +2516,7 @@ void Particle_SnowDraw(s_Particle* part)
      * input vector must be the 8-byte SVECTOR, not the 6-byte SVECTOR3, or it
      * overreads the stack (Linux/ASan abort in Particle_SnowDraw). */
     SVECTOR     particlePosQ8;
+    s32         zCamera;
 #else
     SVECTOR3    particlePosQ8;
 #endif
@@ -2703,6 +2704,14 @@ void Particle_SnowDraw(s_Particle* part)
 
         gte_stsxy(&polyFt3->x0);
         gte_stszotz(&zScreenStart);
+#ifdef SH_PC_PORT
+        /* The three billboard corners share one projected center. Capture its
+         * real camera-space SZ explicitly so the renderer always classifies
+         * snow as depth-tested 3D, even when a derived-corner PGXP shadow is
+         * unavailable. Transparent snow tests against walls but never writes
+         * depth, so flakes behind rooms/ceilings are rejected naturally. */
+        gte_stsz(&zCamera);
+#endif
 
         if (D_800C39A0 == 1 || D_800C39A0 == 4)
         {
@@ -2809,12 +2818,18 @@ void Particle_SnowDraw(s_Particle* part)
 #endif
 
 #if defined(MAP1_S00) || defined(MAP6_S00)
+#ifdef SH_PC_PORT
+            PsyX_SetNextPrimSzExact((u16)zCamera, (u16)zCamera, (u16)zCamera, (u16)zCamera);
+#endif
             addPrim(&g_OrderingTable0[g_ActiveBufferIdx].org[zScreenStart], polyFt3);
 #elif defined(MAP7_S03)
             if (zScreenStart > 64 && D_800F23D4 > Q12(7.0f))
             {
                 zScreenStart = 64;
             }
+#ifdef SH_PC_PORT
+            PsyX_SetNextPrimSzExact((u16)zCamera, (u16)zCamera, (u16)zCamera, (u16)zCamera);
+#endif
             addPrim(&g_OrderingTable0[g_ActiveBufferIdx].org[zScreenStart], polyFt3);
 #else
             switch (sharedData_800DD591_0_s00)
@@ -2822,11 +2837,17 @@ void Particle_SnowDraw(s_Particle* part)
                 case 2:
                     if ((zScreenStart + 256) < ORDERING_TABLE_SIZE - 1)
                     {
+#ifdef SH_PC_PORT
+                        PsyX_SetNextPrimSzExact((u16)zCamera, (u16)zCamera, (u16)zCamera, (u16)zCamera);
+#endif
                         addPrim(&g_OrderingTable0[g_ActiveBufferIdx].org[zScreenStart + 256], polyFt3);
                     }
                     break;
 
                 default:
+#ifdef SH_PC_PORT
+                    PsyX_SetNextPrimSzExact((u16)zCamera, (u16)zCamera, (u16)zCamera, (u16)zCamera);
+#endif
                     addPrim(&g_OrderingTable0[g_ActiveBufferIdx].org[zScreenStart], polyFt3);
                     break;
             }

--- a/src/maps/particle_acid.c
+++ b/src/maps/particle_acid.c
@@ -97,6 +97,12 @@ bool sharedFunc_800CB1B0_4_s03(POLY_FT4** poly, s32 idx)
                                Q12_TO_Q8(ptr->field_12C.vx) - (u16)ptr->field_0.field_0.vx,
                                Q12_TO_Q8(ptr->field_12C.vy) - ptr->field_0.field_0.vy,
                                Q12_TO_Q8(ptr->field_12C.vz) - ptr->field_0.field_0.vz);
+#ifdef SH_PC_PORT
+        PGXP_VectorRegisterQ12(&ptr->field_138,
+                               ptr->field_12C.vx - Q8_TO_Q12((s16)ptr->field_0.field_0.vx),
+                               ptr->field_12C.vy - Q8_TO_Q12(ptr->field_0.field_0.vy),
+                               ptr->field_12C.vz - Q8_TO_Q12(ptr->field_0.field_0.vz));
+#endif
 
         gte_ldv0(&ptr->field_138);
         gte_rtps();
@@ -124,6 +130,15 @@ bool sharedFunc_800CB1B0_4_s03(POLY_FT4** poly, s32 idx)
         setXY1Fast(*poly, (u16)ptr->field_140.vx + (u16)ptr->field_150, ptr->field_140.vy + ptr->field_150);
         setXY2Fast(*poly, (u16)ptr->field_140.vx - (u16)ptr->field_150, ptr->field_140.vy - ptr->field_150);
         setXY3Fast(*poly, (u16)ptr->field_140.vx + (u16)ptr->field_150, ptr->field_140.vy - ptr->field_150);
+#ifdef SH_PC_PORT
+        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+        {
+            Shadow_CopyScreenOffset(&(*poly)->x0, &ptr->field_140);
+            Shadow_CopyScreenOffset(&(*poly)->x1, &ptr->field_140);
+            Shadow_CopyScreenOffset(&(*poly)->x2, &ptr->field_140);
+            Shadow_CopyScreenOffset(&(*poly)->x3, &ptr->field_140);
+        }
+#endif
 
         ptr->field_15C = 128 - ((temp_a3 << 7) / (D_800C4418.field_C + 1));
         ptr->field_15C = (ptr->field_15C * func_80055D78(ptr->field_12C.vx, ptr->field_12C.vy, ptr->field_12C.vz)) >> 8;
@@ -150,6 +165,15 @@ bool sharedFunc_800CB1B0_4_s03(POLY_FT4** poly, s32 idx)
 
         next  = *poly + 1;
         *next = *(*poly);
+#ifdef SH_PC_PORT
+        if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+        {
+            Shadow_CopyScreenOffset(&next->x0, &ptr->field_140);
+            Shadow_CopyScreenOffset(&next->x1, &ptr->field_140);
+            Shadow_CopyScreenOffset(&next->x2, &ptr->field_140);
+            Shadow_CopyScreenOffset(&next->x3, &ptr->field_140);
+        }
+#endif
 
         addPrim(&g_OrderingTable0[g_ActiveBufferIdx].org[(ptr->field_144 - 0x20) >> 3], *poly);
         *poly += 1;
@@ -288,6 +312,12 @@ bool sharedFunc_800CC004_4_s03(POLY_FT4** poly, s32 idx)
                            Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].field_0.vx_0) - (u16)ptr->field_0.field_0.vx,
                            Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].vy_8) - ptr->field_0.field_0.vy,
                            Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].field_4.vz_4) - ptr->field_0.field_0.vz);
+#ifdef SH_PC_PORT
+    PGXP_VectorRegisterQ12(&ptr->field_12C,
+                           sharedData_800DFB7C_0_s00[idx].field_0.vx_0 - Q8_TO_Q12((s16)ptr->field_0.field_0.vx),
+                           sharedData_800DFB7C_0_s00[idx].vy_8 - Q8_TO_Q12(ptr->field_0.field_0.vy),
+                           sharedData_800DFB7C_0_s00[idx].field_4.vz_4 - Q8_TO_Q12(ptr->field_0.field_0.vz));
+#endif
 
     gte_ldv0(&ptr->field_12C);
     gte_rtps();
@@ -315,6 +345,15 @@ bool sharedFunc_800CC004_4_s03(POLY_FT4** poly, s32 idx)
     setXY1Fast(*poly, (u16)ptr->field_134.vx + (u16)ptr->field_13C, ptr->field_134.vy + ptr->field_13C);
     setXY2Fast(*poly, (u16)ptr->field_134.vx - (u16)ptr->field_13C, ptr->field_134.vy - ptr->field_13C);
     setXY3Fast(*poly, (u16)ptr->field_134.vx + (u16)ptr->field_13C, ptr->field_134.vy - ptr->field_13C);
+#ifdef SH_PC_PORT
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_CopyScreenOffset(&(*poly)->x0, &ptr->field_134);
+        Shadow_CopyScreenOffset(&(*poly)->x1, &ptr->field_134);
+        Shadow_CopyScreenOffset(&(*poly)->x2, &ptr->field_134);
+        Shadow_CopyScreenOffset(&(*poly)->x3, &ptr->field_134);
+    }
+#endif
 
     if (sharedData_800DFB7C_0_s00[idx].field_C.s_2.field_0 > Q12(0.4f))
     {
@@ -353,6 +392,15 @@ bool sharedFunc_800CC004_4_s03(POLY_FT4** poly, s32 idx)
 
     next  = *poly + 1;
     *next = *(*poly);
+#ifdef SH_PC_PORT
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_CopyScreenOffset(&next->x0, &ptr->field_134);
+        Shadow_CopyScreenOffset(&next->x1, &ptr->field_134);
+        Shadow_CopyScreenOffset(&next->x2, &ptr->field_134);
+        Shadow_CopyScreenOffset(&next->x3, &ptr->field_134);
+    }
+#endif
 
     addPrim(&g_OrderingTable0[g_ActiveBufferIdx].org[ptr->field_138 >> 3], *poly);
     *poly += 1;

--- a/src/maps/particle_glass.c
+++ b/src/maps/particle_glass.c
@@ -390,6 +390,10 @@ bool sharedFunc_800CD1F8_0_s01(POLY_FT4** poly, s32 idx)
 
     *(s32*)&(*poly)->r0 = (ptr->field_1BC.r + (ptr->field_1BC.g << 8) + (ptr->field_1BC.b << 16) + 0x2E000000);
     *(s32*)&(*poly)->x3 = *(s32*)&ptr->field_1D4.vx;
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_Copy(&(*poly)->x3, &ptr->field_1D4.vx);
+    }
 
     addPrimFast(&g_OrderingTable0[g_ActiveBufferIdx].org[((ptr->field_1C4 - Q12(1.5f)) >= Q12(0.0f)) ? (ptr->field_1C4 - Q12(1.5f)) >> 3 : 0], *poly, 9);
 

--- a/src/maps/particle_water.c
+++ b/src/maps/particle_water.c
@@ -348,6 +348,31 @@ bool sharedFunc_800CBDA8_1_s02(POLY_FT4** poly, s32 idx)
         *(s32*)&ptr->field_144 = ((Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].field_0.vx_0 + ((-ptr->field_168 - ptr->field_16C) >> Q12_SHIFT)) - (u16)ptr->field_0.field_0.vx) & 0xFFFF) +
                                  ((Q12_TO_Q8(ptr->field_176) - ptr->field_0.field_0.vy) << 16);
         ptr->field_144.vz = Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].field_4.vz_4 + ((ptr->field_164 - ptr->field_170) >> Q12_SHIFT)) - ptr->field_0.field_0.vz;
+#ifdef SH_PC_PORT
+        {
+            const s32 x = sharedData_800DFB7C_0_s00[idx].field_0.vx_0;
+            const s32 z = sharedData_800DFB7C_0_s00[idx].field_4.vz_4;
+            const s32 bx = Q8_TO_Q12((s16)ptr->field_0.field_0.vx);
+            const s32 by = Q8_TO_Q12(ptr->field_0.field_0.vy);
+            const s32 bz = Q8_TO_Q12(ptr->field_0.field_0.vz);
+            PGXP_VectorRegisterQ12(&ptr->field_12C,
+                                   x + (ptr->field_168 >> Q12_SHIFT) - bx,
+                                   ptr->field_174 - by,
+                                   z + (-ptr->field_164 >> Q12_SHIFT) - bz);
+            PGXP_VectorRegisterQ12(&ptr->field_134,
+                                   x + (-ptr->field_168 >> Q12_SHIFT) - bx,
+                                   ptr->field_174 - by,
+                                   z + (ptr->field_164 >> Q12_SHIFT) - bz);
+            PGXP_VectorRegisterQ12(&ptr->field_13C,
+                                   x + ((ptr->field_168 - ptr->field_16C) >> Q12_SHIFT) - bx,
+                                   ptr->field_176 - by,
+                                   z + ((-ptr->field_164 - ptr->field_170) >> Q12_SHIFT) - bz);
+            PGXP_VectorRegisterQ12(&ptr->field_144,
+                                   x + ((-ptr->field_168 - ptr->field_16C) >> Q12_SHIFT) - bx,
+                                   ptr->field_176 - by,
+                                   z + ((ptr->field_164 - ptr->field_170) >> Q12_SHIFT) - bz);
+        }
+#endif
     }
     else
     {
@@ -412,6 +437,32 @@ bool sharedFunc_800CBDA8_1_s02(POLY_FT4** poly, s32 idx)
         *(s32*)&ptr->field_144 = ((Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].field_0.vx_0 + ptr->field_0.u_field_EC.field_0[idx0].vy) - (u16)ptr->field_0.field_0.vx) & 0xFFFF) +
                                  ((Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].vy_8 + ptr->field_16C) - ptr->field_0.field_0.vy) << 16);
         ptr->field_144.vz      = Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].field_4.vz_4 + ptr->field_0.u_field_FC.field_0[idx0].vy) - ptr->field_0.field_0.vz;
+#ifdef SH_PC_PORT
+        {
+            const s32 x = sharedData_800DFB7C_0_s00[idx].field_0.vx_0;
+            const s32 y = sharedData_800DFB7C_0_s00[idx].vy_8;
+            const s32 z = sharedData_800DFB7C_0_s00[idx].field_4.vz_4;
+            const s32 bx = Q8_TO_Q12((s16)ptr->field_0.field_0.vx);
+            const s32 by = Q8_TO_Q12(ptr->field_0.field_0.vy);
+            const s32 bz = Q8_TO_Q12(ptr->field_0.field_0.vz);
+            PGXP_VectorRegisterQ12(&ptr->field_12C,
+                                   x + ptr->field_0.u_field_EC.field_0[idx0].vx - bx,
+                                   y - by,
+                                   z + ptr->field_0.u_field_FC.field_0[idx0].vx - bz);
+            PGXP_VectorRegisterQ12(&ptr->field_134,
+                                   x + ptr->field_0.u_field_EC.field_0[idx0].vy - bx,
+                                   y - by,
+                                   z + ptr->field_0.u_field_FC.field_0[idx0].vy - bz);
+            PGXP_VectorRegisterQ12(&ptr->field_13C,
+                                   x + ptr->field_0.u_field_EC.field_0[idx0].vx - bx,
+                                   y + ptr->field_16C - by,
+                                   z + ptr->field_0.u_field_FC.field_0[idx0].vx - bz);
+            PGXP_VectorRegisterQ12(&ptr->field_144,
+                                   x + ptr->field_0.u_field_EC.field_0[idx0].vy - bx,
+                                   y + ptr->field_16C - by,
+                                   z + ptr->field_0.u_field_FC.field_0[idx0].vy - bz);
+        }
+#endif
     }
 
     gte_ldv3c(&ptr->field_12C);
@@ -441,6 +492,10 @@ bool sharedFunc_800CBDA8_1_s02(POLY_FT4** poly, s32 idx)
     }
 
     *(s32*)&(*poly)->x3 = *(s32*)&ptr->field_14C;
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_Copy(&(*poly)->x3, &ptr->field_14C);
+    }
 
     temp_v1_13          = sharedData_800DFB7C_0_s00[idx].field_C.s_1.field_0;
     *(s32*)&(*poly)->u0 = ((temp_v1_13 & 0x2) * 16) + 0x40 + ((ptr->field_17C + ((temp_v1_13 & 0x1) << 6)) << 8) + 0xE0000;
@@ -728,6 +783,13 @@ void sharedFunc_800CCE60_1_s02(void)
             setXY1Fast(poly, ptr->field_13C[k][1].vx, ptr->field_13C[k][1].vy);
             setXY2Fast(poly, ptr->field_13C[k + 1][0].vx, ptr->field_13C[k + 1][0].vy);
             setXY3Fast(poly, ptr->field_13C[k + 1][1].vx, ptr->field_13C[k + 1][1].vy);
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_Copy(&poly->x0, &ptr->field_13C[k][0]);
+                Shadow_Copy(&poly->x1, &ptr->field_13C[k][1]);
+                Shadow_Copy(&poly->x2, &ptr->field_13C[k + 1][0]);
+                Shadow_Copy(&poly->x3, &ptr->field_13C[k + 1][1]);
+            }
 
             setSemiTrans(poly, 1);
 

--- a/src/maps/unk_draw.c
+++ b/src/maps/unk_draw.c
@@ -315,6 +315,15 @@ bool sharedFunc_800CB040_1_s05(POLY_FT4** poly, s32 idx)
     *(s32*)&(*poly)->x1 = *(s32*)&ptr->field_140 + halfSizeFloor + (halfSizeCeil << 16);
     *(s32*)&(*poly)->x2 = *(s32*)&ptr->field_140 + halfSizeCeil + (halfSizeFloor << 16);
     *(s32*)&(*poly)->x3 = *(s32*)&ptr->field_140 + halfSizeFloor + (halfSizeFloor << 16);
+#ifdef SH_PC_PORT
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_CopyScreenOffset(&(*poly)->x0, &ptr->field_140);
+        Shadow_CopyScreenOffset(&(*poly)->x1, &ptr->field_140);
+        Shadow_CopyScreenOffset(&(*poly)->x2, &ptr->field_140);
+        Shadow_CopyScreenOffset(&(*poly)->x3, &ptr->field_140);
+    }
+#endif
 
     addPrimFast(&g_OrderingTable0[g_ActiveBufferIdx].org[ptr->field_13C >> 3], *poly, 9);
     *poly += 1;
@@ -431,6 +440,15 @@ bool sharedFunc_800CB884_1_s05(POLY_FT4** poly, s32 idx) // 0x800CCF50
         setXY2Fast(*poly, ptr->field_140.vx, ptr->field_140.vy + 1);
         setXY3Fast(*poly, (u16)ptr->field_140.vx + 1, ptr->field_140.vy + 1);
     }
+#ifdef SH_PC_PORT
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_CopyScreenOffset(&(*poly)->x0, &ptr->field_140);
+        Shadow_CopyScreenOffset(&(*poly)->x1, &ptr->field_140);
+        Shadow_CopyScreenOffset(&(*poly)->x2, &ptr->field_140);
+        Shadow_CopyScreenOffset(&(*poly)->x3, &ptr->field_140);
+    }
+#endif
 
     addPrimFast(&g_OrderingTable0[g_ActiveBufferIdx].org[ptr->field_13C >> 3], *poly, 9);
     *poly += 1;

--- a/src/maps/unk_draw_m1s01.c
+++ b/src/maps/unk_draw_m1s01.c
@@ -257,6 +257,15 @@ bool sharedFunc_800CBB30_1_s01(POLY_FT4** poly, s32 idx)
         setXY2Fast(*poly, ptr->field_138.vx, ptr->field_138.vy + 1);
         setXY3Fast(*poly, (u16)ptr->field_138.vx + 1, ptr->field_138.vy + 1);
     }
+#ifdef SH_PC_PORT
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_CopyScreenOffset(&(*poly)->x0, &ptr->field_138);
+        Shadow_CopyScreenOffset(&(*poly)->x1, &ptr->field_138);
+        Shadow_CopyScreenOffset(&(*poly)->x2, &ptr->field_138);
+        Shadow_CopyScreenOffset(&(*poly)->x3, &ptr->field_138);
+    }
+#endif
 
 #ifdef SH_PC_PORT
     /* field_134 passed the `<= 0` check above but the OT bias can push it

--- a/src/maps/unk_draw_m1s03.c
+++ b/src/maps/unk_draw_m1s03.c
@@ -136,6 +136,15 @@ bool sharedFunc_800CE688_1_s03(POLY_FT4** poly, s32 idx)
             setXY1Fast(*poly, (u16)scratchData->x_140 + scratchData->field_148.u16, scratchData->y_142 - (s16)scratchData->field_148.u16);
             setXY2Fast(*poly, (u16)scratchData->x_140 - scratchData->field_148.u16, scratchData->y_142 + (s16)scratchData->field_148.u16);
             setXY3Fast(*poly, (u16)scratchData->x_140 + scratchData->field_148.u16, scratchData->y_142 + (s16)scratchData->field_148.u16);
+#ifdef SH_PC_PORT
+            if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+            {
+                Shadow_CopyScreenOffset(&(*poly)->x0, &scratchData->x_140);
+                Shadow_CopyScreenOffset(&(*poly)->x1, &scratchData->x_140);
+                Shadow_CopyScreenOffset(&(*poly)->x2, &scratchData->x_140);
+                Shadow_CopyScreenOffset(&(*poly)->x3, &scratchData->x_140);
+            }
+#endif
 
             setRGB0Fast(*poly, 0x40, 0x40, 0x40);
 

--- a/src/maps/unk_draw_m1s05.c
+++ b/src/maps/unk_draw_m1s05.c
@@ -91,6 +91,12 @@ bool sharedFunc_800CBF74_1_s05(POLY_FT4** poly, s32 idx)
                            Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].field_0.vx_0) - (u16)ptr->field_0.field_0.vx,
                            Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].vy_8) - ptr->field_0.field_0.vy,
                            Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].field_4.vz_4) - ptr->field_0.field_0.vz);
+#ifdef SH_PC_PORT
+    PGXP_VectorRegisterQ12(&ptr->cameraRotation,
+                           sharedData_800DFB7C_0_s00[idx].field_0.vx_0 - Q8_TO_Q12((s16)ptr->field_0.field_0.vx),
+                           sharedData_800DFB7C_0_s00[idx].vy_8 - Q8_TO_Q12(ptr->field_0.field_0.vy),
+                           sharedData_800DFB7C_0_s00[idx].field_4.vz_4 - Q8_TO_Q12(ptr->field_0.field_0.vz));
+#endif
 
     gte_ldv0(&ptr->cameraRotation);
     gte_rtps();
@@ -112,6 +118,15 @@ bool sharedFunc_800CBF74_1_s05(POLY_FT4** poly, s32 idx)
     setXY1Fast(*poly, (u16)ptr->field_144.vx + (u16)ptr->field_148, ptr->field_144.vy - ptr->field_14C);
     setXY2Fast(*poly, (u16)ptr->field_144.vx - (u16)ptr->field_148, ptr->field_144.vy + ptr->field_14C);
     setXY3Fast(*poly, (u16)ptr->field_144.vx + (u16)ptr->field_148, ptr->field_144.vy + ptr->field_14C);
+#ifdef SH_PC_PORT
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_CopyScreenOffset(&(*poly)->x0, &ptr->field_144);
+        Shadow_CopyScreenOffset(&(*poly)->x1, &ptr->field_144);
+        Shadow_CopyScreenOffset(&(*poly)->x2, &ptr->field_144);
+        Shadow_CopyScreenOffset(&(*poly)->x3, &ptr->field_144);
+    }
+#endif
 
     *(u32*)&(*poly)->u0 = 0x530000;
     *(u32*)&(*poly)->u1 = 0x6B001F;
@@ -207,6 +222,22 @@ bool sharedFunc_800CC618_1_s05(POLY_FT4** poly, s32 idx)
     temp3             = (u16)ptr->field_168;
     ptr->field_144.vz = (Q12_TO_Q8(sharedData_800DFB7C_0_s00[idx].field_4.vz_4) - ptr->field_0.field_0.vz) - temp3;
 
+#ifdef SH_PC_PORT
+    {
+        const s32 x = sharedData_800DFB7C_0_s00[idx].field_0.vx_0;
+        const s32 y = sharedData_800DFB7C_0_s00[idx].vy_8;
+        const s32 z = sharedData_800DFB7C_0_s00[idx].field_4.vz_4;
+        const s32 bx = Q8_TO_Q12((s16)ptr->field_0.field_0.vx);
+        const s32 by = Q8_TO_Q12(ptr->field_0.field_0.vy);
+        const s32 bz = Q8_TO_Q12(ptr->field_0.field_0.vz);
+        const s32 radius = Q8_TO_Q12((u16)ptr->field_168);
+        PGXP_VectorRegisterQ12(&ptr->collision, x - bx - radius, y - by, z - bz + radius);
+        PGXP_VectorRegisterQ12(&ptr->field_134, x - bx + radius, y - by, z - bz + radius);
+        PGXP_VectorRegisterQ12(&ptr->field_13C, x - bx - radius, y - by, z - bz - radius);
+        PGXP_VectorRegisterQ12(&ptr->field_144, x - bx + radius, y - by, z - bz - radius);
+    }
+#endif
+
     gte_ldv3c(&ptr->collision);
     gte_rtpt();
     gte_stsxy3_g3(*poly);
@@ -225,6 +256,10 @@ bool sharedFunc_800CC618_1_s05(POLY_FT4** poly, s32 idx)
     }
 
     *(s32*)&(*poly)->x3 = *(s32*)&ptr->field_15C;
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_Copy(&(*poly)->x3, &ptr->field_15C);
+    }
 
     ptr->field_164 = (ptr->field_160 * (func_80055D78(sharedData_800DFB7C_0_s00[idx].field_0.vx_0, sharedData_800DFB7C_0_s00[idx].vy_8, sharedData_800DFB7C_0_s00[idx].field_4.vz_4))) >> 7;
     ptr->field_160 = CLAMP_HIGH(ptr->field_160, ptr->field_164);
@@ -489,6 +524,15 @@ bool sharedFunc_800CCF30_1_s05(POLY_FT4** poly, s32 idx)
     setXY1Fast(*poly, (u16)ptr->field_140.vx - (u16)ptr->field_144.vx, ptr->field_140.vy - ptr->field_144.vy);
     setXY2Fast(*poly, (u16)ptr->field_13C.vx + (u16)ptr->field_144.vx, ptr->field_13C.vy + ptr->field_144.vy);
     setXY3Fast(*poly, (u16)ptr->field_140.vx + (u16)ptr->field_144.vx, ptr->field_140.vy + ptr->field_144.vy);
+#ifdef SH_PC_PORT
+    if (g_PsxUsePgxp || g_PsyX_UsePerPixelFlashlight)
+    {
+        Shadow_CopyScreenOffset(&(*poly)->x0, &ptr->field_13C);
+        Shadow_CopyScreenOffset(&(*poly)->x1, &ptr->field_140);
+        Shadow_CopyScreenOffset(&(*poly)->x2, &ptr->field_13C);
+        Shadow_CopyScreenOffset(&(*poly)->x3, &ptr->field_140);
+    }
+#endif
 
     *(u32*)&(*poly)->u0 = (sharedData_800DFB7C_0_s00[idx].field_B * 0xC00) + 0x010E4000;
     *(u32*)&(*poly)->u1 = (sharedData_800DFB7C_0_s00[idx].field_B * 0xC00) + 0x6D407F;


### PR DESCRIPTION
## Summary

- preserve exact camera, model-root, and dynamic-vertex transforms before Q12-to-Q8 truncation
- carry precise PGXP provenance through particles, water, decals, ribbons, subdivided quads, and CPU-built screen geometry
- cover manual flashlight and lens-flare projections with coherent XY and depth
- update the PsyCross submodule with precise transforms, coplanar world ordering, transparent depth handling, and the world depth buffer
- attach exact camera-space depth to snow billboards so walls and ceilings occlude indoor/out-of-room particles
- enable PGXP by default in the shipped configuration

## Dependency

Depends on SlickAmogus/PsyCross#11. The submodule pointer in this branch references merge commit `2aaba2a` from that PR.

## Rendering behavior

- static opaque world geometry keeps PS1 ordering for coplanar layers while the visible layer writes final depth
- remaining opaque 3D geometry depth-tests against the completed world depth
- transparent 3D geometry depth-tests without writing depth and uses a slope-aware bias to preserve surface overlays
- snow uses explicit camera-space SZ, preventing particles behind rooms, walls, and ceilings from leaking through
- UI, lines, rectangles, and fallback 2D paths retain painter ordering

## Compatibility

The original integer GTE outputs and gameplay calculations are unchanged. Exact data is carried in a separate rendering side channel and falls back safely when provenance is unavailable. PGXP-disabled rendering retains the legacy path. The branch is merged with the current `pc-port`, including whole-map far projection and the Linux/macOS texture-pack build fix.

## Validation

- clean Windows rebuild completed successfully after the upstream merge (634 build steps)
- `SilentHillPC.exe` and all 42 map DLLs link successfully
- 10-second runtime smoke test completed without OpenGL, GLSL, shader-link, assertion, or fatal errors
- `git diff --check` passes in both repositories
- launcher and runtime configuration both default to `use_pgxp = 1`

Targeted in-game verification is still requested for coplanar save pads, rugs, papers, blood decals, and indoor snow visibility.