### PR TITLE
fix: Air Screamer invisible on LP64 (GsCOORDINATE2.flg 4-byte layout)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -41,6 +41,21 @@ jobs:
           cd pc_port
           chmod +x build.sh
           ./build.sh
+          # The compile-time LP64 layout guard runs HERE: the build fails if the
+          # _Static_assert(offsetof(GsCOORDINATE2, coord) == 4) in
+          # pc_port/include/psyq/libgs.h ever breaks (the class behind the
+          # invisible Air Screamer).
+
+      - name: LP64 runtime smoke (skips cleanly without game data)
+        run: |
+          cd pc_port
+          chmod +x lp64-smoke.sh
+          # No disc image in public CI -> the script exits 0 (SKIP). On a
+          # self-hosted runner with the disc + a save (and Xvfb/xdotool/ffmpeg),
+          # it boots headless, loads the café and runs the Air Screamer fly-by,
+          # failing the job on any crash. See lp64-smoke.sh for the v2 golden-image
+          # step that would also catch silent render regressions.
+          ./lp64-smoke.sh
 
       - name: Stage release files
         run: |

--- a/pc_port/docs/struct_offset_portability.md
+++ b/pc_port/docs/struct_offset_portability.md
@@ -73,6 +73,41 @@ fields by 4 bytes on 64-bit. `field_5C` moves from offset 92 → 96. The old cod
 Ray_MissSet(ray, from, &dir, ((s_RayState*)scratchAddr)->field_5C);
 ```
 
+### Case Study: `GsCOORDINATE2.flg` (the `unsigned long`-SIZE variant)
+
+Not every instance is a *pointer*-growth bug. `unsigned long` is itself 8 bytes on LP64
+(4 on PSX/Windows), so a struct laid out around a leading `unsigned long` shifts on Linux
+with no pointer involved. `GsCOORDINATE2` starts with `unsigned long flg`, then `MATRIX coord`:
+
+```
+PSX / Windows (LLP64):          Linux (LP64):
+  0x0 flg   (unsigned long, 4)    0x0 flg   (unsigned long, 8)
+  0x4 coord (MATRIX)              0x8 coord (MATRIX)   <-- shifted +4
+```
+
+The matched placement function `sharedFunc_800D7560_0_s01` reaches `coord` with
+`mat = (s32*)coords + 1;` — a **word-pointer cast + index** (advance 4 bytes to skip `flg`),
+not the byte-pointer form the greps below catch. On LP64 that lands 4 bytes *inside* the
+8-byte `flg`, so the Air Screamer's per-frame position and rotation are written 4 bytes short
+of `coord`; `coord` never receives a correct transform and the bird is invisible — on Linux
+only, since `flg` is 4 bytes on PSX/Windows and the `+ 1` is correct there.
+
+**Fix**: narrow the field to a fixed 4-byte type in the PC stub header
+(`pc_port/include/psyq/libgs.h`), restoring the PSX layout on every ABI *without editing the
+matched function* (keeping its source byte-identical for the match check):
+
+```c
+unsigned int flg;   /* was `unsigned long` — 8 bytes on LP64 */
+...
+_Static_assert(__builtin_offsetof(GsCOORDINATE2, coord) == 4,
+               "GsCOORDINATE2.coord must be at offset 4 (PSX layout)");
+```
+
+Two general lessons: (1) prefer *retyping* a pure-PSX-data field over patching a call site
+when the struct is used by matched code — it doesn't touch matched source; (2) where a fixed
+offset is load-bearing, guard it with a `_Static_assert` so a regression fails the BUILD
+instead of surfacing as a runtime-only, LP64-only bug.
+
 ### How to Find More Instances
 
 Search the codebase for these patterns:
@@ -83,10 +118,14 @@ grep -rn '(u8\*)\|((s8\*)\|((char\*)' src/ | grep '\[[0-9]'
 
 # Hardcoded struct sizes in pointer arithmetic
 grep -rn '+ [0-9][0-9])' src/ | grep 'u8\*\|s8\*\|char\*'
+
+# Word-pointer cast + small index — steps over a leading `unsigned long`/pointer
+# field (the GsCOORDINATE2.flg class the byte-pointer greps above miss)
+grep -rnE '\((s32|int|u32|s16|u16|short)\s*\*\)[^;]*\)\s*\+\s*[1-9]' src/ pc_port/src/
 ```
 
-Any match where the numeric constant corresponds to a field offset in a struct that contains
-pointers is a potential 64-bit portability bug.
+Any match where the numeric constant (or word index) corresponds to a field offset in a struct
+that contains pointers **or a leading `unsigned long`** is a potential 64-bit portability bug.
 
 ### General Rules for the PC Port
 

--- a/pc_port/include/psyq/libgs.h
+++ b/pc_port/include/psyq/libgs.h
@@ -58,13 +58,31 @@ typedef struct {
 } GsCOORD2PARAM;
 
 typedef struct _GsCOORDINATE2 {
-    unsigned long flg;
+    /* PSX-layout flag word — must stay 4 bytes. It was `unsigned long`, which is
+     * 8 bytes on LP64 (Linux/Steam Deck) and silently pushed `coord` from offset 4
+     * to 8, breaking the PSX-original `(s32*)coords + 1` access (Air Screamer went
+     * invisible). `unsigned int` is 4 bytes on PSX, Windows (LLP64) and Linux
+     * (LP64) alike; every use is `flg = 0/bool`, so narrowing is layout-restoring
+     * and behaviour-preserving. NOTE: the full Sony SDK header
+     * include/psyq/libgs.h also declares GsCOORDINATE2 (kept `unsigned long` —
+     * correct for its 32-bit MIPS matching target). This PC stub is the copy the
+     * LP64 build actually uses, so the fix belongs here, not there. */
+    unsigned int flg;
     MATRIX  coord;
     MATRIX  workm;
     GsCOORD2PARAM *param;
     struct _GsCOORDINATE2 *super;
     struct _GsCOORDINATE2 *sub;
 } GsCOORDINATE2;
+
+/* Build-time tripwire for the layout raw `(s32*)coords + 1` access depends on:
+ * `coord` must sit right after the 4-byte `flg`, at offset 4. Re-widening `flg` or
+ * inserting a field before `coord` now fails the BUILD instead of making the Air
+ * Screamer invisible only at runtime, only on LP64. (A whole-struct sizeof assert
+ * can't be used: the trailing pointers make the total size legitimately differ
+ * between PSX/Windows 4-byte pointers and Linux 8-byte pointers.) */
+_Static_assert(__builtin_offsetof(GsCOORDINATE2, coord) == 4,
+               "GsCOORDINATE2.coord must be at offset 4 (PSX layout)");
 
 typedef struct {
     MATRIX  view;

--- a/pc_port/lp64-smoke.sh
+++ b/pc_port/lp64-smoke.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# lp64-smoke.sh — headless LP64 runtime smoke test.
+#
+# WHY: the invisible Air Screamer and the black inventory items are LP64 bugs —
+# they compile clean and only fail at RUNTIME on 64-bit Linux/Steam Deck, so a
+# Windows/LLP64-only test never sees them. This drives the built Linux binary
+# headlessly and fails if it crashes or a known scene misbehaves.
+#
+# Two layers of protection, this is the second one:
+#   1. COMPILE-TIME (always on, even in public CI with no game data): the
+#      _Static_assert(offsetof(GsCOORDINATE2, coord) == 4) in
+#      pc_port/include/psyq/libgs.h — any LP64 layout regression fails the build.
+#   2. RUNTIME (this script): needs the disc image + a save, so it SKIPS cleanly
+#      (exit 0) when they are absent. Runs for real locally or on a self-hosted
+#      runner that has game data. Deps: Xvfb, xdotool, ffmpeg.
+#
+# Run from pc_port/ (or anywhere — it locates its own build/). Exit 0 = pass/skip,
+# non-zero = a real LP64 runtime failure.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+BUILD="$HERE/build"
+DISPLAY_NUM=":99"
+
+skip() { echo "LP64 SMOKE SKIP: $1"; exit 0; }
+fail() { echo "LP64 SMOKE FAIL: $1"; exit 1; }
+
+[ -x "$BUILD/SilentHillPC" ] || skip "no built binary at $BUILD/SilentHillPC"
+# Runtime needs the disc image (gitignored, never in public CI) and a save file.
+ls "$BUILD"/gamedata/*.bin >/dev/null 2>&1 || skip "no disc image in build/gamedata/ (public CI has none)"
+ls "$BUILD"/gamedata/save/*.MCD >/dev/null 2>&1 || skip "no save file in build/gamedata/save/"
+for dep in Xvfb xdotool ffmpeg; do command -v "$dep" >/dev/null 2>&1 || skip "missing dep: $dep"; done
+
+cleanup() { pkill -x SilentHillPC 2>/dev/null; pkill -f "Xvfb $DISPLAY_NUM" 2>/dev/null; }
+trap cleanup EXIT
+
+# Virtual display (SDL needs a window even headless — a null window is a real
+# crash mode, not a false negative). Windowed 960x720 fits the 1280x800 Xvfb;
+# fullscreen 1080p would fail SDL init on it.
+pkill -f "Xvfb $DISPLAY_NUM" 2>/dev/null; sleep 1
+Xvfb "$DISPLAY_NUM" -screen 0 1280x800x24 -nolisten tcp >/dev/null 2>&1 & disown
+sleep 2
+sed -i -e 's/^fullscreen = .*/fullscreen = 0/' -e 's/^width = .*/width = 960/' \
+       -e 's/^height = .*/height = 720/' "$BUILD/config.cfg"
+
+( cd "$BUILD" && DISPLAY="$DISPLAY_NUM" ALSOFT_DRIVERS=null SDL_AUDIODRIVER=dummy \
+    LIBGL_ALWAYS_SOFTWARE=1 SDL_VIDEODRIVER=x11 ./SilentHillPC ) >/dev/null 2>&1 &
+GAME_PID=$!
+sleep 15
+
+LOG="$(ls -t "$BUILD"/SilentHill_*.log 2>/dev/null | head -1)"
+# Boot-level assertions (catch struct-layout / init regressions).
+kill -0 "$GAME_PID" 2>/dev/null || fail "process died during boot (segfault? SDL init?)"
+[ -n "$LOG" ] || fail "no game log produced"
+grep -qa "Failed to initialise SDL" "$LOG" && fail "SDL init failed"
+grep -qai "segmentation\|abort" "$LOG" && fail "crash in boot log"
+
+# Scene-level: load the save, re-arm + run the Air Screamer fly-by via the dev
+# console, and assert the event runs without crashing. (v2: capture a frame here
+# and diff against a golden image to catch SILENT render regressions — e.g. the
+# invisible bird or the black inventory items — not just crashes.)
+W="$(DISPLAY="$DISPLAY_NUM" xdotool search --name 'Silent Hill' | head -1)" || fail "no window"
+[ -n "$W" ] || fail "game window not found"
+key() { DISPLAY="$DISPLAY_NUM" xdotool keydown --window "$W" "$1"; sleep 0.3;
+        DISPLAY="$DISPLAY_NUM" xdotool keyup --window "$W" "$1"; sleep "${2:-2}"; }
+
+key Return 4          # attract FMV -> title menu
+key Return 3          # LOAD -> load screen
+key c 2.5            # select saved file
+key c 8             # confirm -> in-game
+grep -qa "Active map: map0_s01" "$LOG" || fail "did not reach the café (map0_s01)"
+
+key grave 0.8                                                    # open console
+DISPLAY="$DISPLAY_NUM" xdotool type --window "$W" --delay 150 "setflag 42 0"; sleep 0.5
+key Return 0.5; key grave 5                                      # submit, close, run fly-by
+
+kill -0 "$GAME_PID" 2>/dev/null || fail "crashed during café / Air Screamer fly-by"
+grep -qa "Active map: map0_s01" "$LOG" || fail "left the café unexpectedly"
+
+echo "LP64 SMOKE PASS: booted, reached café, ran the Air Screamer fly-by, no crash"
+exit 0


### PR DESCRIPTION
## Problem
On the Linux / Steam Deck (LP64) build the Air Screamer is invisible when it crashes through
the café window; PSX and Windows render it.

## Cause
`GsCOORDINATE2::flg` is `unsigned long` — 8 bytes on LP64, 4 on PSX/Windows (LLP64) — so
`coord` sits at offset 8 on LP64 instead of 4. The matched placement function
`sharedFunc_800D7560_0_s01` reaches `coord` with `mat = (s32*)coords_8 + 1;` (+4 bytes,
correct only when `flg` is 4 bytes). On LP64 the +4 lands inside the 8-byte `flg`, so the
bird's per-frame position/rotation is written 4 bytes short of `coord`; `coord` never receives
a correct transform and the Air Screamer is invisible — on Linux only.

## Fix
Narrow `flg` to `unsigned int` (4 bytes on PSX/Windows/Linux) in the PC stub header
`pc_port/include/psyq/libgs.h`, restoring the PSX layout on every ABI. The change is in the PC
stub only — it does not touch the matched function, so `air_screamer.c` stays byte-identical
and `Check Executables Match` is unaffected. Every use of `flg` is `flg = 0/bool`, so narrowing
changes no behavior.

A `_Static_assert(offsetof(GsCOORDINATE2, coord) == 4)` pins the layout: re-widening `flg` or
inserting a field before `coord` fails the build instead of resurfacing as a runtime-only,
LP64-only bug.

## Keeping the Linux build on the right path
This bug compiled clean and only failed at runtime on LP64 — the reason Windows-only testing
never caught it. Two guards close that gap:
- **Compile-time:** the `_Static_assert` is compiled on every Linux build (`build-linux.yml`),
  so this layout-regression class fails CI immediately, no game data needed.
- **Runtime:** `lp64-smoke.sh` + a `build-linux.yml` step boot the binary headless and run the
  café Air Screamer fly-by, failing on a crash. It skips cleanly without the disc/save (public
  CI has neither) and runs for real on a runner with game data. Marked where a v2 golden-image
  diff would catch *silent* render regressions, not just crashes.

## Testing
- Linux: builds clean, `offsetof(coord)==4` holds; café loads headless and the fly-by runs
  without crash. With `coord` back at offset 4 the placement write lands correctly, which is
  what restores the (previously invisible) Air Screamer.
- Windows (LLP64): `unsigned int` is 4 bytes there, identical to the old `unsigned long` — no
  change. macOS uses Homebrew GCC (LP64, per `build-macos.yml`); `_Static_assert` /
  `__builtin_offsetof` are standard GCC.

## Docs
`struct_offset_portability.md` gains a case study for this variant (`unsigned long`-size /
word-pointer `(s32*)ptr + 1`, distinct from pointer-growth) and a grep pattern that catches it.

---
**Companion:** #64 — the black inventory-item fix, the same LP64 `unsigned long`-width class in `GsMapModelingData`. Independent of this PR (disjoint files); mergeable in either order.
