### PR TITLE
fix: black inventory item models on LP64 (GsMapModelingData TMD header)

### DIFF
--- a/pc_port/src/stubs/libgs_stub.c
+++ b/pc_port/src/stubs/libgs_stub.c
@@ -1356,12 +1356,17 @@ void GsMapModelingData(unsigned long *p)
     size_t copy_size;
 
     if (!p) return;
-    /* p[0] = flags, p[1] = nobj */
-    nobj = p[1];
+    /* TMD header fields are 32-bit on disc, but this parameter is `unsigned long*`,
+     * which is 8 bytes on LP64 (Linux/Steam Deck) and 4 on LLP64 (Windows). Reading
+     * `p[1]` as unsigned long fetched nobj from offset 8 instead of 4 on LP64 -> a
+     * garbage count -> the early return below -> the TMD is never cached, so
+     * inventory item models link NULL and draw black. Read the header at 32-bit
+     * width so the offsets are correct on both ABIs. */
+    nobj = ((u32*)p)[1];             /* header: [0]=flags, [1]=nobj */
     if (nobj == 0 || nobj > GS_TMD_MAX_OBJS) return;
 
-    /* Object table starts right after flags + nobj (2 u_longs = 8 bytes) */
-    obj_table = (u8*)&p[2];
+    /* Object table starts right after flags + nobj (two u32 = 8 bytes). */
+    obj_table = (u8*)p + 8;
 
     /* Always allocate a fresh slot. Reusing a slot for the same base pointer
      * would overwrite objs[] in-place and invalidate existing GsDOBJ2.tmd


### PR DESCRIPTION
## Problem
On the Linux / Steam Deck (LP64) build, inventory item models render black; Windows renders
them.

## Cause
`GsMapModelingData` (the PC libgs stub) receives the TMD header as `unsigned long *p` — 8 bytes
on LP64, 4 on LLP64 (Windows) — but the TMD header fields are 32-bit on disc. Reading the
object count as `p[1]` fetches it from offset 8 instead of the 32-bit field at offset 4 (and
the object table `p[2]` from offset 16 instead of 8). On LP64 the count comes back garbage,
trips the `nobj == 0 || nobj > MAX` guard, and the function returns without caching the TMD.
`GsGetTMDObject` then returns NULL, the item links no model, and it draws black.

## Fix
Read the header at fixed 32-bit width: `nobj = ((u32*)p)[1]` and `obj_table = (u8*)p + 8` —
correct on both ABIs. The change is in `pc_port/src/stubs/libgs_stub.c`, PC-only stub code that
the 32-bit MIPS matching build never compiles, so `Check Executables Match` is unaffected.

## Testing
- Linux: the item screen renders the models (not black) — e.g. the health-drink and handgun
  previews. `GsMapModelingData` returns a valid object count and links the TMD
  (log: `nobj=34, obj=ok`).
- Windows (LLP64): `unsigned long` is 4 bytes there, so `p[1]`/`p[2]` were already at the right
  offsets — no change.

## Notes
Same LP64 `unsigned long`-width family as the invisible-Air-Screamer fix (#63). Independent of it (disjoint files); mergeable in either order. The
Linux CI smoke test in that PR is the general runtime guard for this class; the v2 golden-image
step noted there would cover the item screen too.
