### PR TITLE
map _strdup to strdup on non-Windows platforms

### DIFF
--- a/pc_port/src/lang_text.c
+++ b/pc_port/src/lang_text.c
@@ -4,6 +4,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef _WIN32
+#define _strdup(s) strdup(s)
+#endif
+
 #include "game.h"
 #include "bodyprog/bodyprog.h" /* g_Font16AtlasImg (FONT16 re-queue on live switch) */
 #include "bodyprog/map/map.h" /* s_MapOverlayHdr, g_pMapOverlayHeader, e_MapIdx */


### PR DESCRIPTION
_strdup() is a Microsoft specific function name. Linux and other POSIX systems provide the equivalent function as strdup().

Without this compatibility definition, builds on Linux may fail because _strdup() is not defined.

The change only affects non Windows builds. Windows continues using the native _strdup() implementation.