### PR TITLE
Display an error message when a Silent Hill bin file isn't provided

### DIFF
--- a/pc_port/include/libcd.h
+++ b/pc_port/include/libcd.h
@@ -1,0 +1,20 @@
+#ifndef SH_PC_PORT_LIBCD_WRAPPER_H
+#define SH_PC_PORT_LIBCD_WRAPPER_H
+
+/* Keep the PsyCross/PSY-Q declarations, then intercept CdInit for the PC port.
+ * pc_port/include is intentionally searched before PsyCross's headers, so this
+ * wrapper can add the startup guard without modifying the upstream submodule. */
+#include_next <libcd.h>
+
+#if defined(SH_PC_PORT) && !defined(SH_LIBCD_NO_DISC_GUARD)
+#ifdef __cplusplus
+extern "C" {
+#endif
+int PcPort_CdInitChecked(void);
+#ifdef __cplusplus
+}
+#endif
+#define CdInit() PcPort_CdInitChecked()
+#endif
+
+#endif /* SH_PC_PORT_LIBCD_WRAPPER_H */

--- a/pc_port/src/disc_guard.c
+++ b/pc_port/src/disc_guard.c
@@ -1,0 +1,42 @@
+#define SH_LIBCD_NO_DISC_GUARD
+#include <libcd.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <SDL.h>
+#include <PsyX/PsyX_public.h>
+
+extern SDL_Window* g_window;
+extern const char* PcPort_GetGameDataPath(void);
+extern const char* PcPort_GetGameDiscPath(void);
+
+int PcPort_CdInitChecked(void)
+{
+    const char* discPath = PcPort_GetGameDiscPath();
+
+    if (!discPath || !discPath[0])
+    {
+        const char* dataPath = PcPort_GetGameDataPath();
+        char message[768];
+
+        snprintf(message, sizeof(message),
+                 "Silent Hill disc image (.bin) not found.\n\n"
+                 "Place a valid .bin file in:\n%s\n\n"
+                 "Then restart the game.",
+                 (dataPath && dataPath[0]) ? dataPath : "./gamedata");
+
+        if (SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
+                                     "Missing Silent Hill disc image",
+                                     message,
+                                     g_window) < 0)
+        {
+            fprintf(stderr, "%s\nSDL error: %s\n", message, SDL_GetError());
+        }
+
+        PsyX_Shutdown();
+        exit(EXIT_FAILURE);
+    }
+
+    return CdInit();
+}


### PR DESCRIPTION
Displays an error message when the Silent Hill bin file is missing on Windows, macOS, and Linux. Before this change, running the build on Linux would just crash, but not provide a reason for the crash. This could potentially confuse users.

**Before:**
<img width="916" height="843" alt="image" src="https://github.com/user-attachments/assets/8ce186a5-9f6c-4585-a5b2-81811be02ab5" />

**After:**
<img width="546" height="480" alt="image" src="https://github.com/user-attachments/assets/e5d9bd5b-c6ca-45bb-aa93-2b7aed7db153" />
