### PR TITLE
Add -skiptogame flag to boot straight into gameplay

### DIFF
--- a/pc_port/CHANGELOG.md
+++ b/pc_port/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Silent Hill PC Port — Changelog
 
+## Unreleased
+- Added `-skiptogame` command-line flag: boots straight into gameplay, skipping the warning screen, logos, intro movie, main menu, difficulty prompt and opening movie. Starts a New Game on NORMAL at the `map` set in config.cfg; if `map` is still the default `map0_s00`, the bus level (`map0_s02`) is used instead.
+- `skip_intros` is now a level rather than an on/off switch: `0` = normal boot, `1` = straight to the main menu (previous behavior), `2` = straight into gameplay (same as `-skiptogame`).
+
 ## beta-2026.07.30.1 -- 2026-07-30
 - Fixed gray void in door transitions
 - Fixed see-through item faces for items the player can pick up

--- a/pc_port/config.cfg
+++ b/pc_port/config.cfg
@@ -32,7 +32,11 @@ disable_culling = 1
 # ensuring all geometry is always available.
 preload_chunks = 1
 
-# Skip intro logos and opening movie (0 = show logos+movie, 1 = go straight to main menu)
+# Skip intro logos and opening movie.
+#   0 = show warning screen, logos and intro movie
+#   1 = go straight to the main menu
+#   2 = go straight into gameplay (auto New Game on NORMAL at the `map` set
+#       below, opening movie skipped). Same as launching with -skiptogame.
 skip_intros = 0
 
 # Preferred disc region when several disc images are in gamedata/ (the

--- a/pc_port/include/pc_config.h
+++ b/pc_port/include/pc_config.h
@@ -47,7 +47,11 @@ typedef struct {
     int cutsceneLineGapMs; /* min silence (ms) between cutscene voice lines — simulates PSX CD
                             * seek latency so tightly-timed lines don't run together. Applied as a
                             * MINIMUM (never shortens an authored gap). 0 = off. Default 300. */
-    int skipIntros;      /* 1 = skip Konami/KCET logos and opening movie, go straight to main menu */
+    int skipIntros;      /* 0 = normal boot; 1 = skip warning/Konami/KCET logos and intro movie, go
+                          * straight to main menu; 2 = additionally auto-start a New Game (NORMAL
+                          * difficulty, `map` from config) and skip the opening movie, so the game
+                          * boots directly into gameplay. Set to 2 by the `-skiptogame` CLI flag.
+                          * Every `skipIntros` test below level 2 stays truthy, so 2 implies 1. */
     int showConsole;     /* EXTERNAL console window only: 1 or 3 = create it, else none.
                           * The ingame console is not config-gated anymore — `~` toggles it
                           * (needs allow_debug_controls). Legacy values 2/3 still parse. */

--- a/pc_port/src/main_pc.c
+++ b/pc_port/src/main_pc.c
@@ -673,6 +673,8 @@ static void PrintBanner(void)
     printf("\n");
 }
 
+static int s_SkipToGameArg = 0;
+
 static void ParseArgs(int argc, char* argv[])
 {
     for (int i = 1; i < argc; i++)
@@ -683,11 +685,16 @@ static void ParseArgs(int argc, char* argv[])
             g_GameDataPath[sizeof(g_GameDataPath) - 1] = '\0';
             i++;
         }
+        else if (strcmp(argv[i], "-skiptogame") == 0)
+        {
+            s_SkipToGameArg = 1;
+        }
         else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0)
         {
             printf("Usage: SilentHillPC [options]\n");
             printf("Options:\n");
             printf("  -data <path>    Path to game data directory or CD image\n");
+            printf("  -skiptogame     Boot straight into gameplay (New Game, NORMAL difficulty)\n");
             printf("  -h, --help      Show this help\n");
             exit(0);
         }
@@ -708,6 +715,20 @@ int main(int argc, char* argv[])
     /* Load config file */
     PcConfig_Load("config.cfg");
     PcAudioConfig_Load("config.cfg");
+
+    /* Applied after the config load, or the parsed `skip_intros` would clobber
+     * it. `map0_s00` is the compiled-in default, so a config that still names it
+     * counts as "no level picked" and gets the bus level instead. */
+    if (s_SkipToGameArg)
+    {
+        g_PcConfig.skipIntros = 2;
+
+        if (strcmp(g_PcConfig.mapName, "map0_s00") == 0)
+        {
+            strncpy(g_PcConfig.mapName, "map0_s02", sizeof(g_PcConfig.mapName) - 1);
+            g_PcConfig.mapName[sizeof(g_PcConfig.mapName) - 1] = '\0';
+        }
+    }
 
     /* Now that we know whether logging is enabled, open the log file (or
      * leave g_ShDebugLog NULL so SH_DBG stays a no-op). */

--- a/pc_port/src/pc_config.c
+++ b/pc_port/src/pc_config.c
@@ -431,7 +431,10 @@ void PcConfig_Load(const char* path)
         }
         else if (strcmp(key, "skip_intros") == 0)
         {
-            g_PcConfig.skipIntros = (atoi(value) != 0);
+            int v = atoi(value);
+            if (v < 0) v = 0;
+            if (v > 2) v = 2;
+            g_PcConfig.skipIntros = v;
         }
         else if (strcmp(key, "show_console") == 0)
         {

--- a/src/bodyprog/events/title.c
+++ b/src/bodyprog/events/title.c
@@ -94,6 +94,18 @@ void GameState_MainMenu_Update(void) // 0x8003AB28
     e_GameState prevState;
     static s32  newGameSelectedDifficultyIdx = 1;
     static s32  prevSavegameCount            = 0;
+#ifdef SH_PC_PORT
+    /* Skip-to-game (`-skiptogame` / skip_intros=2) drives the stock New Game
+     * path instead of duplicating it: arm on the first menu frame, synthesise
+     * the difficulty confirm on the next, then hand off. Consumed on hand-off so
+     * a later warm boot back to the title behaves normally. */
+    static s32  skipToGameStep = 0;
+
+    if (skipToGameStep == 0 && g_PcConfig.skipIntros >= 2)
+    {
+        skipToGameStep = 1;
+    }
+#endif
 
     func_80033548();
 
@@ -225,6 +237,15 @@ void GameState_MainMenu_Update(void) // 0x8003AB28
                         SD_Call(Sfx_MenuMove);
                     }
                 }
+            }
+#endif
+
+#ifdef SH_PC_PORT
+            if (skipToGameStep == 1)
+            {
+                g_MainMenu_SelectedEntry = MainMenuEntry_Start;
+                g_Controller0->clickedBtnFlags |= g_GameWorkPtr->config.controllerConfig.enter;
+                skipToGameStep = 2;
             }
 #endif
 
@@ -389,6 +410,16 @@ void GameState_MainMenu_Update(void) // 0x8003AB28
             }
 
             // Select game difficulty.
+#ifdef SH_PC_PORT
+            /* Placed after the scroll/mouse handling so a stray hover cannot
+             * override NORMAL on the frame the confirm is synthesised. */
+            if (skipToGameStep == 2)
+            {
+                newGameSelectedDifficultyIdx = 1;
+                g_Controller0->clickedBtnFlags |= g_GameWorkPtr->config.controllerConfig.enter;
+                skipToGameStep = 3;
+            }
+#endif
             if (g_Controller0->clickedBtnFlags & g_GameWorkPtr->config.controllerConfig.enter)
             {
 
@@ -457,6 +488,18 @@ void GameState_MainMenu_Update(void) // 0x8003AB28
                     Chara_PositionSet(&g_MapOverlayHdr.mapPoints[0]);
                 }
 
+#ifdef SH_PC_PORT
+                /* GameState_MovieOpening only plays the opening movie and then
+                 * hands off to GameState_MainLoadScreen, so targeting the load
+                 * screen directly drops the movie and nothing else. Consuming the
+                 * latch here leaves a later warm boot on the normal title flow. */
+                if (skipToGameStep == 3)
+                {
+                    NEXT_GAME_STATES[MainMenuEntry_Start] = GameState_MainLoadScreen;
+                    skipToGameStep = 4;
+                }
+#endif
+
                 MemCard_SysDisable();
 
                 prevState                       = g_GameWork.gameState;
@@ -507,6 +550,15 @@ void GameState_MainMenu_Update(void) // 0x8003AB28
 
     if (g_GameWork.gameState == GameState_MainMenu)
     {
+#ifdef SH_PC_PORT
+        /* Skip-to-game passes through the menu for two frames; drawing it would
+         * flash the title art before the fade to gameplay. */
+        if (skipToGameStep != 0 && skipToGameStep < 4)
+        {
+            return;
+        }
+#endif
+
         MainMenu_BackgroundDraw();
         func_8003B560();
 


### PR DESCRIPTION
## What

Adds a `-skiptogame` command-line flag that boots directly into gameplay, skipping the warning screen, Konami/KCET logos, intro movie, main menu, difficulty prompt and opening movie. It starts a New Game on NORMAL difficulty at the `map` set in `config.cfg`.

## Why

`skip_intros = 1` already existed but only gets as far as the main menu — every launch still needs START, a difficulty pick and the opening movie before gameplay. That is a lot of clicking when repeatedly testing a specific map.

## How

`skip_intros` becomes a level rather than a boolean:

| Value | Behaviour |
| --- | --- |
| `0` | Normal boot |
| `1` | Skip to the main menu (previous behaviour, unchanged) |
| `2` | Skip straight into gameplay |

`-skiptogame` simply forces level `2`. No new config field was needed — the two existing `if (g_PcConfig.skipIntros)` sites in `warning_screen.c` and `game_main.c` stay truthy at `2`, so the warning screen and logo skipping come for free.

Rather than duplicating the New Game sequence, a one-shot latch in `GameState_MainMenu_Update` drives the stock path:

1. `MenuState_Main` — select `START` and synthesise the confirm click, using the same technique the existing mouse-input code already uses.
2. `MenuState_DifficultySelector` — force NORMAL and synthesise the confirm. Placed after the scroll/mouse handling so a stray cursor hover cannot override the difficulty.
3. `MenuState_NewGameStart` — retarget `GameState_MovieOpening` to `GameState_MainLoadScreen`, then consume the latch.

So `GameBoot_SavegameInitialize`, `GameBoot_PlayerInit`, `ProcessFlag_NewGame`, `GameBoot_MapLoad` and `GameFs_StreamBinLoad` all run through the retail code path untouched.

Dropping the opening movie is lossless: `GameState_MovieOpening_Update` only calls `open_main(...)` and then `Game_StateSetNext(GameState_MainLoadScreen)`, so targeting the load screen directly loses nothing else.

Because the latch is consumed at hand-off, a later warm boot back to the title screen behaves completely normally — no re-skip loop.

The menu draw is suppressed for the two frames the latch is active so the title art does not flash before the fade. Both calls skipped there (`MainMenu_BackgroundDraw` and `func_8003B560`, a nullsub) are draw-only, so no state is lost.

## Default map

When `map` is still the compiled-in default `map0_s00`, the bus level `map0_s02` is used instead. `map0_s02` is the only map carrying the **Bus** save point (`SysState_SaveMenu1`, `eventParam = 2` in `map0_s02_events_data.c`).

Setting `map` to anything else in `config.cfg` is honoured as-is, so this only affects the untouched-default case.

## Testing

Built clean with `-DSH_BUILD_MAP_DLLS=ON` (716/716 targets) and run:

- `-skiptogame` boots straight to gameplay — log confirms `Active map: map0_s02`, the map overlay load, `processFlags=0x4` (NewGame) with the new-game loadout, `GameStartup`, and live player-collision output with real world coordinates. No FMV entries in the log.
- Without the flag, the normal boot chain is unchanged.
- `skip_intros = 1` still stops at the main menu exactly as before.

## Notes

- No launcher UI change — the flag is command-line only, with `skip_intros = 2` available in `config.cfg` for the same effect.
- Every change outside the shared `title.c` menu function is inside `pc_port/`, and the `title.c` additions are all guarded by `#ifdef SH_PC_PORT`, so PSX-target behaviour is untouched.
