### PR TITLE
big TMD: oversized loose item models, the item-model twin of pc_big_lm

### DIFF
--- a/pc_port/CMakeLists.txt
+++ b/pc_port/CMakeLists.txt
@@ -620,3 +620,29 @@ endif()
 # Install
 # =============================================================================
 install(TARGETS SilentHillPC RUNTIME DESTINATION bin)
+
+# =============================================================================
+# Tests (-DBUILD_TESTING=ON, then ctest)
+# =============================================================================
+if(BUILD_TESTING)
+    enable_testing()
+
+    # Oversized loose ITEM TMD capacity lift (pc_big_tmd.c). Links the real
+    # module against the real file table so path building, slot arithmetic and
+    # the accept/reject verdicts are exercised exactly as the game does them.
+    add_executable(pc_big_tmd_test
+        tests/pc_big_tmd_test.c
+        src/pc_big_tmd.c
+        "${DECOMP_DIR}/src/main/fileinfo.c")
+    target_compile_definitions(pc_big_tmd_test PRIVATE
+        SH_PC_PORT VER_USA SKIP_ASM static_assert=_Static_assert)
+    # include/decomp is a 32-bit shim whose struct layouts do not satisfy the
+    # decomp static asserts on 64-bit, so it is deliberately absent here — the
+    # real headers live under ${DECOMP_DIR}/include.
+    target_include_directories(pc_big_tmd_test PRIVATE
+        "${CMAKE_BINARY_DIR}"
+        include include/psyq_compat src
+        "${DECOMP_DIR}/include" "${DECOMP_DIR}/include/decomp"
+        "${PSYCROSS_DIR}/include/psx" "${PSYCROSS_DIR}/include")
+    add_test(NAME pc_big_tmd_test COMMAND pc_big_tmd_test)
+endif()

--- a/pc_port/include/pc_big_tmd.h
+++ b/pc_port/include/pc_big_tmd.h
@@ -1,0 +1,65 @@
+#ifndef PC_BIG_TMD_H
+#define PC_BIG_TMD_H
+
+/* Oversized loose ITEM TMDs — the item-model twin of pc_big_lm.c.
+ *
+ * Every unique inventory item model in GameFs_UniqueItemModelLoad
+ * (item_screens_3.c) reads into ONE fixed PSX-RAM slab, FS_BUFFER_5. Nearly
+ * eighty UNQ*.TMD files share it, so a replacement larger than its file-table
+ * slot cannot simply be byte-replaced: fsqueue_3.c's loose path refuses it
+ * ("> buf ... for non-TIM read; ignoring loose file") and the disc file loads
+ * instead.
+ *
+ * This registry, keyed by g_FileTable index, validates such a file, hands out
+ * a calloc'd PC-owned buffer, and substitutes it for FS_BUFFER_5 at the single
+ * Fs_QueueStartRead seam in GameFs_UniqueItemModelLoad. Fs_QueueTickRead then
+ * freads into it through the same capacity-lifted byte-replace path pc_big_lm
+ * uses. The consumer side (func_80054A04 / Gfx_Items_Display) resolves the
+ * same substitution so GsMapModelingData parses the lifted buffer.
+ *
+ * STOCK GUARANTEE: Pc_BigTmd_Redirect returns its `dest` argument BY VALUE,
+ * unchanged, unless ALL of these hold — loose files enabled, the loose file
+ * exists, it is strictly larger than the native sector-aligned slot, and it
+ * passes TMD validation. Any miss returns the identical FS_BUFFER_5 pointer,
+ * so the data the native path loads and draws is exactly what it is today. */
+
+#include <stddef.h>
+
+#include "common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* GsMapModelingData (libgs_stub.c) bounds a primitive packet at 64 bytes when
+ * it computes the block extent it memcpy's out of the load buffer. That upper
+ * bound over-reads past EOF for every real TMD — 3368 bytes past the end of
+ * stock UNQ21.TMD — which is harmless inside the 2 MB PSX RAM slab but would
+ * walk off a tight malloc. Every buffer this module hands out is therefore
+ * sized for the stub's own worst-case extent, plus this tail. */
+#define PC_BIGTMD_TAIL_SLACK 64
+
+/* The ONLY redirect entry. Keyed by fileIdx (one of the ~78 UNQ*.TMD ids), so
+ * it is correct for every item that shares FS_BUFFER_5, not just one.
+ *
+ * Returns the buffer Fs_QueueStartRead should load into: a PC-owned buffer for
+ * an accepted oversized loose file, otherwise `dest` unchanged. Also updates
+ * the active-substitution record for `dest` — including CLEARING it on a miss,
+ * so a stock item selected after a modded one resolves back to the slab
+ * instead of drawing the previous item's stale buffer. */
+void* Pc_BigTmd_Redirect(s32 fileIdx, void* dest);
+
+/* Consumer-side resolve: the substituted buffer currently standing in for
+ * `nativeDest`, or `nativeDest` itself when nothing is substituted. Identity
+ * for any pointer this module never redirected. */
+void* Pc_BigTmd_Resolve(void* nativeDest);
+
+/* Capacity of a registered item-TMD destination; 0 for unregistered pointers.
+ * Raises the loose byte-replace size gate in Fs_QueueTickRead. */
+size_t Pc_BigTmd_DestCapacity(const void* dest);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PC_BIG_TMD_H */

--- a/pc_port/src/pc_big_tmd.c
+++ b/pc_port/src/pc_big_tmd.c
@@ -1,0 +1,585 @@
+/* Oversized loose ITEM TMDs — the item-model twin of pc_big_lm.c.
+ *
+ * GameFs_UniqueItemModelLoad (item_screens_3.c) reads EVERY unique
+ * inventory item model into the single fixed PSX-RAM slab FS_BUFFER_5. The
+ * slab is sized by the disc file table, and the next allocated slot sits
+ * 0x1000 bytes above it, so an enlarged replacement model has nowhere to go:
+ * fsqueue_3.c's loose byte-replace path measures the file against the slot,
+ * finds it too big for a non-TIM read, and logs
+ *   [LOOSE/WARN] ... > buf ... for non-TIM read; ignoring loose file
+ * before falling back to the disc.
+ *
+ * This module lifts that ceiling the same way pc_big_lm.c does for character
+ * ILMs: probe the loose file, validate it, hand out a calloc'd PC-owned buffer
+ * keyed by g_FileTable index, and substitute it for FS_BUFFER_5 at the single
+ * Fs_QueueStartRead seam. Fs_QueueTickRead's gate then rises to that buffer's
+ * real capacity via Pc_BigTmd_DestCapacity, and the consumer side resolves the
+ * same substitution so GsMapModelingData parses the lifted buffer.
+ *
+ * ---------------------------------------------------------------------------
+ * STOCK-UNCHANGED GUARANTEE
+ * ---------------------------------------------------------------------------
+ * Pc_BigTmd_Redirect returns its `dest` argument unchanged unless ALL of:
+ *   1. g_PcConfig.allowLooseFiles is set                (default 0),
+ *   2. gamedata/load/ITEM/<NAME>.TMD opens,
+ *   3. its size is STRICTLY GREATER than the native sector-aligned slot,
+ *   4. it passes BigTmd_Validate.
+ * Condition 1 alone means an unmodified install never allocates, never probes
+ * past the one config test, and never logs. With loose files ON but no
+ * oversized item file present, BigTmd_Ensure returns NULL at the `fileSize <=
+ * tableSize` test — the ordinary byte-replace path keeps ownership exactly as
+ * before. Every remaining failure path (path too long, registry full, calloc
+ * failure, malformed TMD) also returns `dest`. The only pointer the engine can
+ * ever receive other than FS_BUFFER_5 is a validated, correctly sized buffer.
+ * Pc_BigTmd_DestCapacity returns 0 for FS_BUFFER_5, so the FS gate is
+ * untouched on the stock path as well.
+ *
+ * ---------------------------------------------------------------------------
+ * STALE-POINTER POLICY  (pc_big_lm.c's lesson)
+ * ---------------------------------------------------------------------------
+ * All ~78 UNQ*.TMD ids share FS_BUFFER_5, so switching items MUST NOT leave
+ * the previous item's buffer standing in. BigTmd_SetActive is therefore called
+ * on EVERY Redirect, including misses, where it CLEARS the record. A stock
+ * item loaded after a modded one resolves back to the slab. Buffers are never
+ * freed while the process lives (a grown replacement retires the old buffer
+ * into a bounded table instead), so no resolve can ever return freed memory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "game.h"
+#include "main/fsqueue.h"
+#include "main/fileinfo.h"
+
+#include "pc_big_tmd.h"
+#include "pc_config.h"
+#include "sh_log.h"
+
+/* Draw-time guard in func_8004BD74 (item_screens_cam.c) skips any
+ * object with vern==0 || vern>0x2000 || primn==0 || primn>0x2000. Reject at
+ * load time instead of letting a bad file reach GsSortObject4J. */
+#define BIGTMD_MAX_VERT 0x2000
+#define BIGTMD_MAX_PRIM 0x2000
+
+/* GsMapModelingData (libgs_stub.c) bails on nobj > GS_TMD_MAX_OBJS. */
+#define BIGTMD_MAX_OBJ  48
+
+/* File layout: u32 id, u32 flags, u32 nobj, then nobj * 28-byte entries.
+ * Object-table offsets are relative to the table itself (file + 12). */
+#define BIGTMD_HDR_SIZE  12
+#define BIGTMD_OBJ_SIZE  28
+
+/* Only the two TMD ids the SH1 item path produces. */
+#define BIGTMD_ID_FIXP   0x41
+#define BIGTMD_ID_PLAIN  0x40
+
+/* Absolute sanity cap so a wrong/huge file can never drive a giant calloc. */
+#define BIGTMD_MAX_FILE  (16 * 1024 * 1024)
+
+enum
+{
+    BIGTMD_STATE_ACCEPTED = 1,
+    BIGTMD_STATE_REJECTED = 2
+};
+
+typedef struct
+{
+    s16    fileIdx;  /* g_FileTable index — THE key */
+    u8*    buf;      /* calloc'd substitute; NULL until Redirect allocates */
+    size_t cap;
+    long   fileSize; /* validated loose size this verdict refers to */
+    size_t needBytes;/* GsMapModelingData's worst-case read extent */
+    u8     state;
+} PcBigTmd;
+
+/* Only oversized files (accepted or rejected) take a slot, so ordinary play
+ * — where every probe misses or fits — never fills the table. */
+#define PC_BIGTMD_MAX 64
+static PcBigTmd s_bigTmd[PC_BIGTMD_MAX];
+static int      s_bigTmdCount;
+
+/* A buffer displaced by a mid-session file-size change stays tracked and
+ * allocated: a queue entry may still hold it as entry->data. Freeing it would
+ * be exactly the stale-pointer class of bug that produced wild GTE reads in
+ * the character path. */
+#define PC_BIGTMD_RETIRED_MAX 32
+static struct
+{
+    u8*    buf;
+    size_t cap;
+} s_retired[PC_BIGTMD_RETIRED_MAX];
+static int s_retiredCount;
+
+/* Active substitutions, keyed by the NATIVE destination the engine asked for
+ * (FS_BUFFER_5 in practice). Tiny because only the item path uses this. */
+#define PC_BIGTMD_ACTIVE_MAX 4
+static struct
+{
+    void* nativeDest;
+    u8*   buf;
+} s_active[PC_BIGTMD_ACTIVE_MAX];
+
+/* fsqueue_3.c's loose fopen, so this probe and the FS probe see exactly the
+ * same on-disk namespace (including the Linux case-insensitive fallback). */
+extern FILE* Pc_LooseFOpen(const char* path, const char* mode);
+
+/* Built exactly as Fs_QueueTickRead builds its probe path. */
+static int BigTmd_LoosePath(s32 fileIdx, char* out, size_t outSize)
+{
+    const s_FileInfo* file   = &g_FileTable[fileIdx];
+    const char*       folder = g_FilePaths[file->pathIdx];
+    char              strippedFolder[16];
+    char              nameBuf[32];
+    size_t            fi;
+    size_t            fl;
+
+    if (folder[0] == '\\')
+    {
+        folder++;
+    }
+    fl = strlen(folder);
+    while (fl > 0 && folder[fl - 1] == '\\')
+    {
+        fl--;
+    }
+    if (fl >= sizeof(strippedFolder))
+    {
+        fl = sizeof(strippedFolder) - 1;
+    }
+    for (fi = 0; fi < fl; fi++)
+    {
+        strippedFolder[fi] = folder[fi];
+    }
+    strippedFolder[fl] = '\0';
+
+    Fs_GetFileName(nameBuf, fileIdx);
+
+    return snprintf(out, outSize, "gamedata/load/%s/%s", strippedFolder, nameBuf) < (int)outSize;
+}
+
+static long BigTmd_ProbeSize(const char* path)
+{
+    long  sz = -1;
+    FILE* f  = Pc_LooseFOpen(path, "rb");
+
+    if (f == NULL)
+    {
+        return -1;
+    }
+    if (fseek(f, 0, SEEK_END) == 0)
+    {
+        sz = ftell(f);
+    }
+    fclose(f);
+    return sz;
+}
+
+static u8* BigTmd_Slurp(const char* path, long expectSize)
+{
+    u8*   buf = NULL;
+    FILE* f   = Pc_LooseFOpen(path, "rb");
+
+    if (f == NULL)
+    {
+        return NULL;
+    }
+    buf = (u8*)malloc((size_t)expectSize);
+    if (buf != NULL && fread(buf, 1, (size_t)expectSize, f) != (size_t)expectSize)
+    {
+        free(buf);
+        buf = NULL;
+    }
+    fclose(f);
+    return buf;
+}
+
+static u32 BigTmd_Rd32(const u8* p)
+{
+    return (u32)p[0] | ((u32)p[1] << 8) | ((u32)p[2] << 16) | ((u32)p[3] << 24);
+}
+
+/* Validate the raw file and compute the buffer extent GsMapModelingData will
+ * actually touch.
+ *
+ * Two separate jobs, both required:
+ *
+ *  (a) REJECT malformed data before it can reach GsSortObject4J. Header id and
+ *      nobj, every object's vern/primn against the draw-time guard's own
+ *      limits, every vertex/normal array inside the file, and a full walk of
+ *      the primitive packet chain (each packet is a 4-byte header whose [1]
+ *      byte is ilen, the payload length in words) so a truncated or lying
+ *      primn cannot run the drawer off the end.
+ *
+ *  (b) SIZE the buffer. The stub bounds a primitive at 64 bytes when it
+ *      computes the block extent it memcpy's out of the load buffer, which
+ *      over-reads past EOF for every real TMD (3368 bytes past the end of
+ *      stock UNQ21.TMD). Inside the 2 MB PSX RAM slab that is harmless; out of
+ *      a tight malloc it is a heap over-read. Reproduce the stub's arithmetic
+ *      exactly and size the allocation for it. */
+static int BigTmd_Validate(const u8* b, long fileSize, size_t* outNeed, char* err, size_t errCap)
+{
+    u32    id;
+    u32    nobj;
+    u32    i;
+    u32    dataStart = 0xFFFFFFFFu;
+    u32    dataEnd   = 0;
+    size_t copySize;
+    size_t need;
+
+    if (fileSize < BIGTMD_HDR_SIZE + BIGTMD_OBJ_SIZE)
+    {
+        snprintf(err, errCap, "too small (%ld B)", fileSize);
+        return 0;
+    }
+
+    id   = BigTmd_Rd32(b + 0);
+    nobj = BigTmd_Rd32(b + 8);
+
+    if (id != BIGTMD_ID_FIXP && id != BIGTMD_ID_PLAIN)
+    {
+        snprintf(err, errCap, "bad TMD id 0x%x", (unsigned)id);
+        return 0;
+    }
+    if (nobj == 0 || nobj > BIGTMD_MAX_OBJ)
+    {
+        /* nobj > GS_TMD_MAX_OBJS makes GsMapModelingData return early, so the
+         * item would link NULL and silently not draw. Reject loudly instead. */
+        snprintf(err, errCap, "nobj=%u outside (0,%d]", (unsigned)nobj, BIGTMD_MAX_OBJ);
+        return 0;
+    }
+    if ((long)(BIGTMD_HDR_SIZE + (size_t)nobj * BIGTMD_OBJ_SIZE) > fileSize)
+    {
+        snprintf(err, errCap, "object table (%u objs) past EOF", (unsigned)nobj);
+        return 0;
+    }
+
+    for (i = 0; i < nobj; i++)
+    {
+        const u8* o = b + BIGTMD_HDR_SIZE + (size_t)i * BIGTMD_OBJ_SIZE;
+        u32       vertop = BigTmd_Rd32(o + 0);
+        u32       vern   = BigTmd_Rd32(o + 4);
+        u32       nortop = BigTmd_Rd32(o + 8);
+        u32       norn   = BigTmd_Rd32(o + 12);
+        u32       primtop= BigTmd_Rd32(o + 16);
+        u32       primn  = BigTmd_Rd32(o + 20);
+        u32       p;
+        u32       k;
+
+        /* Mirror the draw-time guard so nothing it would skip ever loads. */
+        if (vern == 0 || vern > BIGTMD_MAX_VERT)
+        {
+            snprintf(err, errCap, "obj%u vern=%u outside (0,%d]",
+                     (unsigned)i, (unsigned)vern, BIGTMD_MAX_VERT);
+            return 0;
+        }
+        if (primn == 0 || primn > BIGTMD_MAX_PRIM)
+        {
+            snprintf(err, errCap, "obj%u primn=%u outside (0,%d]",
+                     (unsigned)i, (unsigned)primn, BIGTMD_MAX_PRIM);
+            return 0;
+        }
+        if (norn > BIGTMD_MAX_VERT)
+        {
+            snprintf(err, errCap, "obj%u norn=%u > %d", (unsigned)i, (unsigned)norn, BIGTMD_MAX_VERT);
+            return 0;
+        }
+
+        /* Arrays must lie inside the file. Offsets are from the object table
+         * (file + 12), matching the stub's `base + raw[n]` resolution. */
+        if ((long)BIGTMD_HDR_SIZE + (long)vertop + (long)vern * 8 > fileSize ||
+            (long)BIGTMD_HDR_SIZE + (long)nortop + (long)norn * 8 > fileSize)
+        {
+            snprintf(err, errCap, "obj%u vert/norm array past EOF", (unsigned)i);
+            return 0;
+        }
+
+        /* Walk the packet chain: [olen][ilen][flag][mode] then ilen words. */
+        p = (u32)BIGTMD_HDR_SIZE + primtop;
+        for (k = 0; k < primn; k++)
+        {
+            u32 ilen;
+            u32 total;
+
+            if ((long)p + 4 > fileSize)
+            {
+                snprintf(err, errCap, "obj%u prim %u header past EOF", (unsigned)i, (unsigned)k);
+                return 0;
+            }
+            ilen  = b[p + 1];
+            total = 4u + ilen * 4u;
+            if (ilen == 0 || (long)p + (long)total > fileSize)
+            {
+                snprintf(err, errCap, "obj%u prim %u (ilen=%u) past EOF",
+                         (unsigned)i, (unsigned)k, (unsigned)ilen);
+                return 0;
+            }
+            p += total;
+        }
+
+        /* (b) the stub's own extent arithmetic, verbatim. */
+        if (vertop  < dataStart) dataStart = vertop;
+        if (nortop  < dataStart) dataStart = nortop;
+        if (primtop < dataStart) dataStart = primtop;
+        if (vertop  + vern  * 8u  > dataEnd) dataEnd = vertop  + vern  * 8u;
+        if (nortop  + norn  * 8u  > dataEnd) dataEnd = nortop  + norn  * 8u;
+        if (primtop + primn * 64u > dataEnd) dataEnd = primtop + primn * 64u;
+    }
+
+    copySize = (dataStart < dataEnd) ? (size_t)(dataEnd - dataStart) : 0;
+    copySize += (size_t)nobj * BIGTMD_OBJ_SIZE;
+    if (copySize == 0)
+    {
+        copySize = 4096;
+    }
+
+    /* The stub memcpy's copySize bytes starting at file+12, and separately
+     * resolves pointers up to file+12+dataEnd. Cover both. */
+    need = (size_t)BIGTMD_HDR_SIZE + (copySize > (size_t)dataEnd ? copySize : (size_t)dataEnd);
+    if (need < (size_t)fileSize)
+    {
+        need = (size_t)fileSize;
+    }
+    *outNeed = need;
+    return 1;
+}
+
+static PcBigTmd* BigTmd_Find(s32 fileIdx)
+{
+    int i;
+
+    for (i = 0; i < s_bigTmdCount; i++)
+    {
+        if (s_bigTmd[i].fileIdx == (s16)fileIdx)
+        {
+            return &s_bigTmd[i];
+        }
+    }
+    return NULL;
+}
+
+/* Probe + validate an oversized loose file for fileIdx, caching the verdict.
+ * Returns NULL when the file is absent, fits its slot, or the table is full —
+ * every one of those is a "leave the native path alone" answer. Never
+ * allocates the substitute buffer; Redirect does that. */
+static PcBigTmd* BigTmd_Ensure(s32 fileIdx, const char* path)
+{
+    long      fileSize;
+    long      tableSize;
+    PcBigTmd* e;
+    char      err[160];
+    u8*       tmp;
+    size_t    need = 0;
+    int       ok;
+
+    fileSize  = BigTmd_ProbeSize(path);
+    tableSize = (long)Fs_GetFileSectorAlignedSize(fileIdx);
+
+    if (fileSize <= tableSize)
+    {
+        /* Absent, or fits the slot: the ordinary byte-replace path owns it and
+         * behaviour is identical to today. THIS is the stock-path exit. */
+        return NULL;
+    }
+    if (fileSize > BIGTMD_MAX_FILE)
+    {
+        SH_DBG("[BIGTMD] %s: %ld B exceeds %d B cap — native item model",
+               path, fileSize, BIGTMD_MAX_FILE);
+        return NULL;
+    }
+
+    e = BigTmd_Find(fileIdx);
+    if (e != NULL && e->fileSize == fileSize)
+    {
+        return e; /* cached verdict, accepted or rejected */
+    }
+
+    /* New or size-changed file: re-validate before anything trusts it. */
+    tmp = BigTmd_Slurp(path, fileSize);
+    if (tmp == NULL)
+    {
+        snprintf(err, sizeof(err), "read failed");
+        ok = 0;
+    }
+    else
+    {
+        ok = BigTmd_Validate(tmp, fileSize, &need, err, sizeof(err));
+    }
+    free(tmp);
+
+    if (e == NULL)
+    {
+        if (s_bigTmdCount >= PC_BIGTMD_MAX)
+        {
+            SH_DBG("[BIGTMD] registry full (%d), ignoring %s — native item model",
+                   PC_BIGTMD_MAX, path);
+            return NULL;
+        }
+        e = &s_bigTmd[s_bigTmdCount++];
+        memset(e, 0, sizeof(*e));
+        e->fileIdx = (s16)fileIdx;
+    }
+    e->fileSize  = fileSize;
+    e->needBytes = need;
+
+    if (!ok)
+    {
+        e->state = BIGTMD_STATE_REJECTED;
+        SH_DBG("[BIGTMD] reject: %s (%ld B): %s — native item model", path, fileSize, err);
+        return e;
+    }
+
+    if (e->buf != NULL)
+    {
+        if (e->cap < need + PC_BIGTMD_TAIL_SLACK)
+        {
+            /* Grew: retire (do not free) the old buffer — a queue entry may
+             * still name it as entry->data. */
+            if (s_retiredCount < PC_BIGTMD_RETIRED_MAX)
+            {
+                s_retired[s_retiredCount].buf = e->buf;
+                s_retired[s_retiredCount].cap = e->cap;
+                s_retiredCount++;
+            }
+            else
+            {
+                SH_DBG("[BIGTMD] retired-buffer table full; %p untracked", (void*)e->buf);
+            }
+            e->buf = NULL;
+            e->cap = 0;
+        }
+        else
+        {
+            /* Reused buffer: re-zero so the slack beyond the new file stays
+             * zero after the queue's fread writes only fileSize bytes. */
+            memset(e->buf, 0, e->cap);
+        }
+    }
+
+    e->state = BIGTMD_STATE_ACCEPTED;
+    SH_DBG("[BIGTMD] ACCEPT %s: %ld B (slot %ld B, need %zu B)",
+           path, fileSize, tableSize, need);
+    return e;
+}
+
+static void BigTmd_SetActive(void* nativeDest, u8* buf)
+{
+    int i;
+    int freeSlot = -1;
+
+    for (i = 0; i < PC_BIGTMD_ACTIVE_MAX; i++)
+    {
+        if (s_active[i].nativeDest == nativeDest)
+        {
+            s_active[i].buf = buf; /* buf == NULL clears the substitution */
+            return;
+        }
+        if (s_active[i].nativeDest == NULL && freeSlot < 0)
+        {
+            freeSlot = i;
+        }
+    }
+    if (buf == NULL)
+    {
+        return; /* nothing recorded, nothing to clear */
+    }
+    if (freeSlot < 0)
+    {
+        SH_DBG("[BIGTMD] active table full; %p not substituted", nativeDest);
+        return;
+    }
+    s_active[freeSlot].nativeDest = nativeDest;
+    s_active[freeSlot].buf        = buf;
+}
+
+void* Pc_BigTmd_Redirect(s32 fileIdx, void* dest)
+{
+    char      path[176];
+    PcBigTmd* e;
+
+    if (dest == NULL)
+    {
+        return dest;
+    }
+
+    /* Fast, allocation-free stock exit: loose files off (the default) means
+     * this function is a pure identity with one boolean test. */
+    if (!g_PcConfig.allowLooseFiles || fileIdx < 0 || fileIdx >= FS_FILE_COUNT)
+    {
+        BigTmd_SetActive(dest, NULL);
+        return dest;
+    }
+    if (!BigTmd_LoosePath(fileIdx, path, sizeof(path)))
+    {
+        BigTmd_SetActive(dest, NULL);
+        return dest;
+    }
+
+    e = BigTmd_Ensure(fileIdx, path);
+    if (e == NULL || e->state != BIGTMD_STATE_ACCEPTED)
+    {
+        /* CLEAR: the previous item may have been redirected, and all ~78
+         * UNQ*.TMD ids share this destination. Without this a stock item after
+         * a modded one would resolve to the modded buffer and draw the wrong
+         * (or a since-overwritten) model. */
+        BigTmd_SetActive(dest, NULL);
+        return dest;
+    }
+
+    if (e->buf == NULL)
+    {
+        size_t cap = e->needBytes + PC_BIGTMD_TAIL_SLACK;
+        u8*    buf = (u8*)calloc(1, cap);
+
+        if (buf == NULL)
+        {
+            SH_DBG("[BIGTMD] %s: calloc(%zu) failed — native item model", path, cap);
+            BigTmd_SetActive(dest, NULL);
+            return dest;
+        }
+        e->buf = buf;
+        e->cap = cap;
+        SH_DBG("[BIGTMD] REDIRECT %s (file %d) -> %p cap %zu", path, (int)fileIdx,
+               (void*)e->buf, e->cap);
+    }
+
+    BigTmd_SetActive(dest, e->buf);
+    return e->buf;
+}
+
+void* Pc_BigTmd_Resolve(void* nativeDest)
+{
+    int i;
+
+    if (nativeDest == NULL)
+    {
+        return nativeDest;
+    }
+    for (i = 0; i < PC_BIGTMD_ACTIVE_MAX; i++)
+    {
+        if (s_active[i].nativeDest == nativeDest && s_active[i].buf != NULL)
+        {
+            return s_active[i].buf;
+        }
+    }
+    return nativeDest;
+}
+
+size_t Pc_BigTmd_DestCapacity(const void* dest)
+{
+    int i;
+
+    if (dest == NULL)
+    {
+        return 0;
+    }
+    for (i = 0; i < s_bigTmdCount; i++)
+    {
+        if (s_bigTmd[i].buf == dest && s_bigTmd[i].state == BIGTMD_STATE_ACCEPTED)
+        {
+            return s_bigTmd[i].cap;
+        }
+    }
+    return 0;
+}

--- a/pc_port/tests/pc_big_tmd_test.c
+++ b/pc_port/tests/pc_big_tmd_test.c
@@ -1,0 +1,253 @@
+/* pc_big_tmd_test.c — oversized loose ITEM TMD capacity lift.
+ *
+ * Links the REAL pc_big_tmd.c against the REAL g_FileTable/g_FilePaths from
+ * src/main/fileinfo.c, so path building, slot arithmetic and the accept/reject
+ * verdicts are exercised exactly as the game does them.
+ *
+ * Covers:
+ *   1. loose files OFF  -> pure identity, no substitution  (STOCK GUARANTEE)
+ *   2. loose files ON, no file present -> identity          (STOCK GUARANTEE)
+ *   3. loose file present but FITS the slot -> identity     (STOCK GUARANTEE)
+ *   4. oversized VALID file -> substituted, capacity lifted, resolve follows,
+ *      buffer sized for GsMapModelingData's worst-case read extent
+ *   5. oversized MALFORMED files -> rejected, identity restored
+ *   6. item switching: modded item then stock item must NOT keep the modded
+ *      buffer (the shared-FS_BUFFER_5 stale-pointer hazard)
+ *   7. a second, different UNQ id also lifts (keyed per file, not per item)
+ */
+/* NDEBUG is set by the RelWithDebInfo build; this test IS its assertions, so
+ * force them on before <assert.h> is pulled in. */
+#undef NDEBUG
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include "common.h"
+#include "main/fileinfo.h"
+#include "pc_big_tmd.h"
+#include "pc_config.h"
+
+/* --- minimal environment the module needs ------------------------------- */
+s_PcConfig g_PcConfig;
+
+FILE* Pc_LooseFOpen(const char* path, const char* mode) { return fopen(path, mode); }
+
+FILE* g_ShDebugLog;
+int   g_ShDebugEchoStdout;
+void (*g_ShOverlayPushLine)(const char*);
+
+/* fileinfo.c references the audio table from unrelated helpers this test never
+ * calls; a zeroed definition satisfies the link without pulling in sound code. */
+#include "bodyprog/sound/sound_system.h"
+s_AudioItemData g_AudioData[1];
+
+/* --- test data ---------------------------------------------------------- */
+#define UNQ21 1516 /* ITEM/UNQ21.TMD */
+#define UNQ22 1517 /* ITEM/UNQ22.TMD */
+
+static u8 g_slab[64 * 1024]; /* stands in for FS_BUFFER_5 */
+
+static void wr32(u8* p, u32 v)
+{
+    p[0] = (u8)v; p[1] = (u8)(v >> 8); p[2] = (u8)(v >> 16); p[3] = (u8)(v >> 24);
+}
+
+/* Build a syntactically valid TMD: 1 object, `nv` verts, `np` F3 prims
+ * (ilen=3 -> 16 bytes each), padded out to at least `padTo` bytes. */
+static size_t build_tmd(u8* out, u32 id, u32 nobj, u32 nv, u32 np, size_t padTo)
+{
+    const u32 primBytes = np * 16u;
+    u32       primtop, vertop, nortop;
+    size_t    total;
+    u32       i;
+
+    primtop = nobj * 28u;                /* offsets are from file+12 */
+    vertop  = primtop + primBytes;
+    nortop  = vertop + nv * 8u;
+    total   = 12u + nortop + nv * 8u;
+
+    memset(out, 0, padTo > total ? padTo : total);
+    wr32(out + 0, id);
+    wr32(out + 4, 0);
+    wr32(out + 8, nobj);
+    for (i = 0; i < nobj; i++)
+    {
+        u8* o = out + 12 + i * 28;
+        wr32(o + 0,  vertop);  wr32(o + 4,  nv);
+        wr32(o + 8,  nortop);  wr32(o + 12, nv);
+        wr32(o + 16, primtop); wr32(o + 20, np);
+        wr32(o + 24, 0);
+    }
+    for (i = 0; i < np; i++)
+    {
+        u8* p = out + 12 + primtop + i * 16;
+        p[0] = 3;    /* olen */
+        p[1] = 3;    /* ilen -> 4 + 12 = 16 bytes */
+        p[2] = 0x20; /* flag/mode: untextured flat tri */
+        p[3] = 0x20;
+    }
+    return padTo > total ? padTo : total;
+}
+
+static void write_file(const char* path, const u8* b, size_t n)
+{
+    FILE* f = fopen(path, "wb");
+    assert(f != NULL);
+    assert(fwrite(b, 1, n, f) == n);
+    fclose(f);
+}
+
+static void rm(const char* path) { remove(path); }
+
+static const char* P21 = "gamedata/load/ITEM/UNQ21.TMD";
+static const char* P22 = "gamedata/load/ITEM/UNQ22.TMD";
+
+int main(void)
+{
+    static u8 buf[512 * 1024];
+    size_t    n;
+    void*     r;
+    long      slot21;
+
+    assert(mkdir("gamedata", 0755) == 0 || 1);
+    mkdir("gamedata/load", 0755);
+    mkdir("gamedata/load/ITEM", 0755);
+    rm(P21); rm(P22);
+
+    /* g_FileTable is filled at runtime from the detected disc region. Without
+     * this every blockCount is 0, the slot size is 0, and the test would pass
+     * vacuously. */
+    Fs_InitFileTableForRegion(Region_USA);
+
+    slot21 = Fs_GetFileSectorAlignedSize(UNQ21);
+    printf("UNQ21 slot = %ld bytes\n", slot21);
+    assert(slot21 == 6144); /* blockCount 18 * 256 = 4608 -> sector-aligned 6144 */
+
+    /* --- 1. loose files OFF: pure identity, even with a big file present -- */
+    n = build_tmd(buf, 0x41, 1, 900, 1800, 0);
+    assert((long)n > slot21);
+    write_file(P21, buf, n);
+
+    g_PcConfig.allowLooseFiles = 0;
+    r = Pc_BigTmd_Redirect(UNQ21, g_slab);
+    assert(r == g_slab);
+    assert(Pc_BigTmd_Resolve(g_slab) == g_slab);
+    assert(Pc_BigTmd_DestCapacity(g_slab) == 0);
+    printf("1. loose OFF -> identity                     OK\n");
+
+    /* --- 2. loose ON, file absent: identity ------------------------------ */
+    rm(P21);
+    g_PcConfig.allowLooseFiles = 1;
+    r = Pc_BigTmd_Redirect(UNQ21, g_slab);
+    assert(r == g_slab);
+    assert(Pc_BigTmd_Resolve(g_slab) == g_slab);
+    assert(Pc_BigTmd_DestCapacity(g_slab) == 0);
+    printf("2. loose ON, no file -> identity             OK\n");
+
+    /* --- 3. loose file present but FITS the slot: identity --------------- */
+    n = build_tmd(buf, 0x41, 1, 40, 60, 0);
+    assert((long)n <= slot21);
+    write_file(P21, buf, n);
+    r = Pc_BigTmd_Redirect(UNQ21, g_slab);
+    assert(r == g_slab); /* ordinary byte-replace path keeps ownership */
+    assert(Pc_BigTmd_Resolve(g_slab) == g_slab);
+    assert(Pc_BigTmd_DestCapacity(g_slab) == 0);
+    printf("3. fits slot -> identity (byte-replace owns) OK\n");
+
+    /* --- 4. oversized + valid: substituted -------------------------------- */
+    n = build_tmd(buf, 0x41, 1, 900, 1800, 0);
+    write_file(P21, buf, n);
+    r = Pc_BigTmd_Redirect(UNQ21, g_slab);
+    assert(r != NULL && r != g_slab);
+    {
+        size_t cap = Pc_BigTmd_DestCapacity(r);
+        /* Worst case GsMapModelingData reaches: 12 + max(copySize, dataEnd),
+         * where a prim is bounded at 64 bytes. Must be far beyond the file. */
+        u32 primtop = 28, np = 1800, nv = 900;
+        u32 vertop  = primtop + np * 16u;
+        u32 nortop  = vertop + nv * 8u;
+        u32 dataEnd = nortop + nv * 8u;
+        u32 pEnd    = primtop + np * 64u;
+        size_t need;
+        if (pEnd > dataEnd) dataEnd = pEnd;
+        need = 12u + (size_t)dataEnd + 28u; /* copySize includes the obj table */
+        printf("   file=%zu cap=%zu (need>=%zu)\n", n, cap, need);
+        assert(cap >= need);
+        assert(cap > n); /* strictly larger than the file: the stub over-reads */
+        assert(Pc_BigTmd_DestCapacity(g_slab) == 0); /* slab never registered */
+        assert(Pc_BigTmd_Resolve(g_slab) == r);      /* consumer follows */
+    }
+    printf("4. oversized valid -> substituted + lifted   OK\n");
+
+    /* --- 5. malformed oversized files are rejected ------------------------ */
+    {
+        struct { const char* what; u32 id, nobj, nv, np; } bad[] = {
+            { "bad id",        0x99, 1,  900, 1800 },
+            { "nobj=0",        0x41, 0,  900, 1800 },
+            { "nobj>48",       0x41, 60, 900, 1800 },
+        };
+        unsigned i;
+        for (i = 0; i < sizeof(bad) / sizeof(bad[0]); i++)
+        {
+            n = build_tmd(buf, bad[i].id, bad[i].nobj ? bad[i].nobj : 1,
+                          bad[i].nv, bad[i].np, 0);
+            /* re-stamp the header fields the builder normalised */
+            wr32(buf + 0, bad[i].id);
+            wr32(buf + 8, bad[i].nobj);
+            write_file(P21, buf, n + i + 1); /* +i keeps sizes distinct so the
+                                              * verdict cache re-validates */
+            r = Pc_BigTmd_Redirect(UNQ21, g_slab);
+            assert(r == g_slab);
+            assert(Pc_BigTmd_Resolve(g_slab) == g_slab);
+            printf("5.%u malformed (%-10s) -> rejected, identity OK\n", i + 1, bad[i].what);
+        }
+
+        /* vern over the draw-time guard (0x2000) */
+        n = build_tmd(buf, 0x41, 1, 900, 1800, 0);
+        wr32(buf + 12 + 4, 0x2001);
+        write_file(P21, buf, n);
+        r = Pc_BigTmd_Redirect(UNQ21, g_slab);
+        assert(r == g_slab);
+        printf("5.4 malformed (%-10s) -> rejected, identity OK\n", "vern huge");
+        /* truncated: object table claims arrays past EOF */
+        n = build_tmd(buf, 0x41, 1, 900, 1800, 0);
+        write_file(P21, buf, n / 2);
+        r = Pc_BigTmd_Redirect(UNQ21, g_slab);
+        assert(r == g_slab);
+        printf("5.5 malformed (%-10s) -> rejected, identity OK\n", "truncated");
+    }
+
+    /* --- 6. item switch must not leave the modded buffer standing --------- */
+    n = build_tmd(buf, 0x41, 1, 900, 1800, 0);
+    write_file(P21, buf, n);
+    r = Pc_BigTmd_Redirect(UNQ21, g_slab);            /* modded item */
+    assert(r != g_slab);
+    assert(Pc_BigTmd_Resolve(g_slab) == r);
+    {
+        void* stock = Pc_BigTmd_Redirect(UNQ22, g_slab); /* stock item, no file */
+        assert(stock == g_slab);
+        assert(Pc_BigTmd_Resolve(g_slab) == g_slab);  /* substitution CLEARED */
+    }
+    printf("6. modded->stock item clears substitution    OK\n");
+
+    /* --- 7. a different UNQ id lifts too (keyed per file) ----------------- */
+    n = build_tmd(buf, 0x41, 1, 700, 1400, 0);
+    write_file(P22, buf, n);
+    {
+        void* a = Pc_BigTmd_Redirect(UNQ21, g_slab);
+        void* b;
+        assert(a != g_slab);
+        b = Pc_BigTmd_Redirect(UNQ22, g_slab);
+        assert(b != g_slab);
+        assert(b != a); /* separate buffers, separate registry entries */
+        assert(Pc_BigTmd_Resolve(g_slab) == b);
+        assert(Pc_BigTmd_DestCapacity(a) > 0 && Pc_BigTmd_DestCapacity(b) > 0);
+    }
+    printf("7. second UNQ id lifts independently         OK\n");
+
+    rm(P21); rm(P22);
+    printf("\npc_big_tmd_test: ALL PASS\n");
+    return 0;
+}

--- a/src/bodyprog/items/item_screens_3.c
+++ b/src/bodyprog/items/item_screens_3.c
@@ -3224,6 +3224,28 @@ void func_800539A4(s32 scrollDirection, s32 arg1) // 0x800539A4
  *   map being loaded.
  */
 
+#ifdef SH_PC_PORT
+/* Oversized loose item-TMD support (pc_port/src/pc_big_tmd.c).
+ *
+ * Every one of the ~79 arms below reads into the SINGLE fixed slab
+ * FS_BUFFER_5, whose usable size is set by the disc file table. A loose
+ * replacement larger than its slot cannot be byte-replaced, so Fs_QueueTickRead
+ * refuses it and the disc file loads instead.
+ *
+ * Rather than edit 79 identical call sites — where one being missed would make
+ * the mechanism silently wrong for that item — the read is intercepted for the
+ * extent of this ONE function. Pc_BigTmd_Redirect is keyed by fileIdx, so each
+ * item gets its own verdict, and it returns `dest` unchanged unless an
+ * oversized, valid loose file exists for that exact file id. With
+ * allow_loose_files off (the default) it is one boolean test that returns the
+ * incoming pointer, so the slab the read lands in is FS_BUFFER_5 as before.
+ *
+ * #undef'd immediately after the function so no other call site is affected. */
+#include "pc_big_tmd.h"
+#define Fs_QueueStartRead(fileIdx_, dest_) \
+    Fs_QueueStartRead((fileIdx_), Pc_BigTmd_Redirect((fileIdx_), (dest_)))
+#endif
+
 void GameFs_UniqueItemModelLoad(u8 itemId) // 0x80053B08
 {
     switch (itemId)
@@ -3522,6 +3544,10 @@ void GameFs_UniqueItemModelLoad(u8 itemId) // 0x80053B08
             break;
     }
 }
+
+#ifdef SH_PC_PORT
+#undef Fs_QueueStartRead
+#endif
 
 void GameFs_Tim00TIMLoad(void) // 0x80053dA0
 {
@@ -4183,7 +4209,16 @@ void func_80054A04(u8 itemId) // 0x80054A04
     g_Items_Transforms[9].trans.vy  = 0;
     g_Items_Transforms[9].trans.vx  = 0;
 
+#ifdef SH_PC_PORT
+    /* Resolve the oversized-item substitution: when this item's model was
+     * redirected into a PC-owned buffer, GsMapModelingData must parse THAT
+     * buffer, not the slab the read never went into. Pc_BigTmd_Resolve is the
+     * identity for any pointer with no active substitution, which is always the
+     * case on stock data — so this stays FS_BUFFER_5 exactly as before. */
+    GameFs_TmdDataAlloc((s32*)Pc_BigTmd_Resolve(FS_BUFFER_5));
+#else
     GameFs_TmdDataAlloc(FS_BUFFER_5);
+#endif
 
 #ifndef SH_PC_PORT
     D_800C3E18[9] = 0; /* PSX BSS aliasing; out of bounds on PC */
@@ -4199,7 +4234,8 @@ void func_80054A04(u8 itemId) // 0x80054A04
      * to render — that's the "invisible health drink / picked-up map
      * shows no model" symptom. */
     {
-        s_TmdFile* _tmd = (s_TmdFile*)FS_BUFFER_5;
+        /* Same substitution resolve as the GameFs_TmdDataAlloc call above. */
+        s_TmdFile* _tmd = (s_TmdFile*)Pc_BigTmd_Resolve(FS_BUFFER_5);
         if (_tmd != NULL) {
             unsigned long*     _hdr = (unsigned long*)&_tmd->flags;
             struct TMD_STRUCT* _obj;

--- a/src/main/fsqueue_3.c
+++ b/src/main/fsqueue_3.c
@@ -12,6 +12,7 @@
 #include "hires_override.h"
 #include "tex_pack.h"
 #include "pc_big_lm.h"
+#include "pc_big_tmd.h"   /* Pc_BigTmd_DestCapacity — oversized loose ITEM TMDs */
 #include "lang_pack.h"    /* Pc_LangPackActive — FONT16 Polish glyph patch */
 #include "font_region.h"  /* Font_PatchPolishGlyphs */
 #include "sh_log.h"
@@ -806,6 +807,14 @@ bool Fs_QueueTickRead(s_FsQueueEntry* entry)
              * capacity; unregistered destinations keep the table-size gate. */
             {
                 size_t bigCap = Pc_BigLm_DestCapacity(entry->data);
+                if (bigCap > bufSize)
+                {
+                    bufSize = bigCap;
+                }
+                /* Same lift for oversized ITEM TMDs (pc_big_tmd.c). Returns 0
+                 * for FS_BUFFER_5 and every other unregistered pointer, so the
+                 * stock item path keeps the exact table-size gate. */
+                bigCap = Pc_BigTmd_DestCapacity(entry->data);
                 if (bigCap > bufSize)
                 {
                     bufSize = bigCap;


### PR DESCRIPTION
## Problem

`pc_big_lm` lifts the file-table size gate for oversized loose **character** ILMs. There is no equivalent for **item** models, so a richer replacement for any `UNQ*.TMD` is silently refused and the disc file loads instead.

The cause is the shared destination. Every arm of `GameFs_UniqueItemModelLoad` reads into the single fixed slab `FS_BUFFER_5`, whose usable size comes from the disc file table. UNQ21 (health drink, file index 1516) is 4,608 B inside a 6,144 B sector-aligned slot, so anything larger trips the non-TIM byte-replace check in `Fs_QueueTickRead`:

```
[LOOSE/WARN] ... > buf ... for non-TIM read; ignoring loose file
```

The mod author gets no crash and no visible error — just the stock model, quietly.

## How it works

`pc_big_tmd` mirrors `pc_big_lm`'s API shape, naming and structure:

| `pc_big_lm` | `pc_big_tmd` |
| --- | --- |
| `Pc_BigLm_Redirect` | `Pc_BigTmd_Redirect` |
| `Pc_BigLm_DestCapacity` | `Pc_BigTmd_DestCapacity` |
| — | `Pc_BigTmd_Resolve` |

1. **Probe + validate.** On load, the loose file for that `g_FileTable` index is probed. Files that are absent or fit the slot return immediately — the ordinary byte-replace path keeps ownership.
2. **Redirect.** An oversized, valid file gets a `calloc`'d PC-owned buffer, substituted for `FS_BUFFER_5` at the load seam.
3. **Lift the gate.** `Fs_QueueTickRead` raises `bufSize` via `Pc_BigTmd_DestCapacity`, immediately alongside the existing `Pc_BigLm_DestCapacity` call.
4. **Resolve.** The consumer side (`func_80054A04`) resolves the same substitution so `GsMapModelingData` parses the lifted buffer rather than the slab the read never went into.

`Pc_BigTmd_Resolve` has no `pc_big_lm` counterpart because the character path substitutes the header pointer the caller already holds, while the item path has a second consumer that independently names `FS_BUFFER_5`.

### Why the read is intercepted rather than edited call-by-call

`GameFs_UniqueItemModelLoad` has ~79 identical `Fs_QueueStartRead(FILE_ITEM_UNQxx_TMD, FS_BUFFER_5)` arms. Editing each one invites exactly one being missed, which would leave that single item quietly broken in a way no test would catch. Instead the call is intercepted for the extent of that one function and `#undef`'d immediately after, so the mechanism is correct for every item sharing the slab — not just the one I tested. `Pc_BigTmd_Redirect` is keyed by `fileIdx`, so each item still gets its own independent verdict.

## Buffers are sized to the parser's reach, not the file

This is the part worth a reviewer's attention, and it is a **latent finding independent of this feature**.

`GsMapModelingData` (`pc_port/src/stubs/libgs_stub.c`) bounds a primitive at 64 bytes when computing the block extent it copies out of the load buffer:

```c
u32 prim_end = raw[4] + raw[5] * 64; /* 64-byte upper bound per prim */
```

Real primitives are smaller than that bound, so the computed extent runs **past EOF for every TMD the game loads**. For stock `UNQ21.TMD`:

```
file size   4608 B   (id 0x41, nobj 1)
obj 0: vertop 3500 vern 64  nortop 4012 norn 66  primtop 28 primn 124
data_start 28  data_end 7964  copy_size 7964
stub reads file+12 .. file+7976  ->  3368 bytes past EOF
```

Inside the 2 MB PSX RAM slab that is harmless — it reads neighbouring resident data. Out of a tight `malloc` it is a heap over-read. So the validator reproduces the stub's arithmetic exactly and sizes every buffer for the stub's own worst-case extent.

**Deliberate divergence, so it doesn't read as a typo:** `PC_BIGTMD_TAIL_SLACK` is 64 where `PC_BIGLM_TAIL_SLACK` is 16. The character path over-reads by a GTE vertex/normal stride; this one over-reads by that per-primitive bound.

## Validation rejects loudly

`nobj > GS_TMD_MAX_OBJS` makes `GsMapModelingData` return early, so the item links NULL and silently fails to draw — the same class of invisible failure this PR is trying to remove. The validator therefore rejects malformed input up front, with a log line naming the file and the reason, and falls back to the native model:

- header id not `0x40`/`0x41`
- `nobj` outside `(0, 48]`
- `vern`/`primn` outside `(0, 0x2000]`, mirroring the draw-time guard in `func_8004BD74`
- vertex/normal arrays extending past EOF
- a truncated or lying primitive packet chain (full walk of the `[olen][ilen][flag][mode]` chain)

## Stock behaviour is unchanged

By construction, not by convention:

- With no oversized loose file registered, `Pc_BigTmd_DestCapacity` returns 0 and the FS gate keeps the exact table-size bound.
- `Pc_BigTmd_Redirect` returns the incoming `FS_BUFFER_5` pointer on every failure path — file absent, fits the slot, path too long, registry full, `calloc` failure, malformed TMD.
- With `allow_loose_files = 0` (the default) it is one boolean test: it never probes, never allocates, never logs.

Verified two ways. **Object-level:** normalising for address relocation, the only functions whose code changes are `GameFs_UniqueItemModelLoad` and `func_80054A04` in `item_screens_3.o` (the two intended seams; the only other delta in that TU is alignment padding in `Gfx_Items_Draw`), and `Fs_QueueTickRead` in `fsqueue_3.o`. **Runtime:** see the controls below.

All ~79 item ids keep sharing one slab, so an item switch must not leave the previous item's buffer standing in. The active-substitution record is therefore updated on *every* `Redirect`, including misses, where it clears — a stock item selected after a modded one resolves back to the slab. Buffers displaced by a mid-session size change are retired into a bounded table rather than freed, since a queue entry may still hold one as `entry->data`.

## Verification

Built and tested on this branch against current `pc-port` (`32d6b6e03`). Linux, GCC, `RelWithDebInfo`.

The full game target builds clean, with no new warnings in the touched files. `ctest` is 8/8.

The unit test links the **real** `pc_big_tmd.c` against the **real** `g_FileTable`/`g_FilePaths` from `src/main/fileinfo.c`, so path building, slot arithmetic and the accept/reject verdicts are exercised exactly as the game does them (`Fs_InitFileTableForRegion(Region_USA)` is called first — without it every `blockCount` is 0 and the test would pass vacuously):

```
$ ./pc_big_tmd_test
UNQ21 slot = 6144 bytes
1. loose OFF -> identity                     OK
2. loose ON, no file -> identity             OK
3. fits slot -> identity (byte-replace owns) OK
   file=43240 cap=115304 (need>=115268)
4. oversized valid -> substituted + lifted   OK
5.1 malformed (bad id    ) -> rejected, identity OK
5.2 malformed (nobj=0    ) -> rejected, identity OK
5.3 malformed (nobj>48   ) -> rejected, identity OK
5.4 malformed (vern huge ) -> rejected, identity OK
5.5 malformed (truncated ) -> rejected, identity OK
6. modded->stock item clears substitution    OK
7. second UNQ id lifts independently         OK

pc_big_tmd_test: ALL PASS
```

The test is behind `BUILD_TESTING`, so it costs a normal build nothing:

```
cmake -B build -DBUILD_TESTING=ON && cmake --build build && ctest --test-dir build
```

### Live, on this branch's binary

Driven against a real boot (disc autodetected, region USA, `map0_s00` loaded) with a 69,192-byte 962-vert / 1,920-prim replacement UNQ21 staged at `gamedata/load/ITEM/UNQ21.TMD`.

`allow_loose_files = 1`:

```
allowLooseFiles=1  slot(1516)=6144  FS_BUFFER_5=0xa8a0740
Redirect -> 0xbab74e0  substituted=1  cap=122984
Resolve(slab) -> 0xbab74e0  follows=1
DestCapacity(slab) = 0
```

`allow_loose_files = 0`, **same oversized file still present** — the negative control:

```
allowLooseFiles=0  slot(1516)=6144  FS_BUFFER_5=0xa8a0740
Redirect -> 0xa8a0740  substituted=0  cap=0
Resolve(slab) -> 0xa8a0740
DestCapacity(slab) = 0
```

Zero `[BIGTMD]` lines were emitted in the stock run. Note `DestCapacity(slab) = 0` in *both* cases: the slab itself is never registered, so the FS gate is untouched for it even while a substitution is live.

The same feature was previously exercised end-to-end through the normal gameplay path on a development branch, where it produced the rendered model in-game:

```
[BIGTMD] ACCEPT gamedata/load/ITEM/UNQ21.TMD: 69192 B (slot 6144 B, need 122920 B)
[BIGTMD] REDIRECT gamedata/load/ITEM/UNQ21.TMD (file 1516) -> cap 122984
[ITEMPICK] unique-item link: id=0x41 nobj=1 obj=ok
```

A control run without the loose directory produced zero `[BIGTMD]` lines — no silent disc fallback masking the result.

The replacement art asset itself is deliberately **not** included here; it isn't needed to review or exercise the loader.

## Limits

- Verified on **native Linux only**. Not built or run on Windows/MSYS2, and not tested against `xbox-port`. The code is plain C with no platform-specific calls and reuses `Pc_LooseFOpen` for the same on-disk namespace as the existing loose path, so I don't expect divergence — but I haven't confirmed it and would rather say so than imply coverage I don't have.
- The `[BIGTMD]` logging is bounded by the verdict cache: one accept or reject line per file, not per load.
- Buffers are intentionally never freed while the process lives, matching `pc_big_lm`'s stale-pointer policy. Bounded at 64 registry entries and 32 retired buffers.

## Unrelated build note

Building the full target with the `rcheevos` submodule uninitialised fails at link, because the `RAWHY`/`RATOAST` console commands in `pc_console_cmd.c` call `Pc_Ra_Why`/`Pc_Ra_PreviewFirst` unconditionally while their definitions are compiled out. `git submodule update --init --recursive` fixes it. Present on a clean `pc-port` checkout, unrelated to this change, and left alone here — flagging it only because a first-time contributor will hit it.
