### PR TITLE
feat(launcher): add mod manager with PE static security verification …

### DIFF
--- a/pc_port/include/dll_security.h
+++ b/pc_port/include/dll_security.h
@@ -1,0 +1,30 @@
+#ifndef DLL_SECURITY_H
+#define DLL_SECURITY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum
+{
+    DLL_SECURITY_OK = 0,
+    DLL_SECURITY_ERR_FILE_OPEN,
+    DLL_SECURITY_ERR_INVALID_PE,
+    DLL_SECURITY_ERR_BLOCKED_IMPORT,
+    DLL_SECURITY_ERR_NO_PLUGIN_EXPORTS
+} DllSecurityResult;
+
+/*
+ * Statically audits a DLL on disk before LoadLibrary to detect malicious imports
+ * and ensure it implements the Silent Hill PC Port plugin contract.
+ *
+ * Returns DLL_SECURITY_OK if valid and safe.
+ * Writes diagnostic message to outReason if provided.
+ */
+DllSecurityResult DllSecurity_AuditPlugin(const char* path, char* outReason, int maxReasonLen);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DLL_SECURITY_H */

--- a/pc_port/include/pc_plugins.h
+++ b/pc_port/include/pc_plugins.h
@@ -1,0 +1,38 @@
+#ifndef PC_PLUGINS_H
+#define PC_PLUGINS_H
+
+#include "game.h"
+#include "types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Silent Hill PC Port - Standard Plugin Lifecycle Signatures
+ * Plugins can export any of these standard engine lifecycle hooks.
+ */
+typedef void        (*SH_Plugin_InitFunc)(void);
+typedef void        (*SH_Plugin_ShutdownFunc)(void);
+typedef void        (*SH_Plugin_NewGameFunc)(void);
+typedef void        (*SH_Plugin_MapLoadFunc)(s32 mapIdx);
+typedef void        (*SH_Plugin_UpdateFunc)(void);
+typedef void        (*SH_Plugin_RenderFunc)(void);
+typedef const char* (*SH_Plugin_GetNameFunc)(void);
+typedef s32         (*SH_Plugin_GetApiVersionFunc)(void);
+
+/*
+ * Core Engine Plugin Manager Interface
+ */
+void Pc_Plugins_Init(void);
+void Pc_Plugins_Shutdown(void);
+void Pc_Plugins_OnNewGame(void);
+void Pc_Plugins_OnMapLoad(s32 mapIdx);
+void Pc_Plugins_OnUpdate(void);
+void Pc_Plugins_OnRender(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PC_PLUGINS_H */

--- a/pc_port/launcher/SilentHillPC_Launcher/ModManager.cs
+++ b/pc_port/launcher/SilentHillPC_Launcher/ModManager.cs
@@ -8,7 +8,7 @@ using System.Runtime.Serialization.Json;
 
 namespace SilentHillPC_Launcher
 {
-    public enum ModType   { Unknown, Texturemods, Load, Fmv }
+    public enum ModType   { Unknown, Texturemods, Load, Fmv, Gameplay, Preset, TotalConversion }
     public enum ModSource { Library, TextureMods }
 
     public class ModEntry
@@ -45,9 +45,12 @@ namespace SilentHillPC_Launcher
                              : IsInPlaceZip ? "Texture pack (.zip, in place)"
                              : IsArchive    ? "Texture pack (.zip)"
                                             : "Texture pack (folder)";
-                    case ModType.Load:        return "Load folder";
-                    case ModType.Fmv:         return "FMV";
-                    default:                  return "Unrecognized";
+                    case ModType.Load:            return "Data Overlay (load/)";
+                    case ModType.Fmv:             return "FMV Video";
+                    case ModType.Gameplay:        return "Gameplay (Code / DLL)";
+                    case ModType.Preset:          return "Config Preset";
+                    case ModType.TotalConversion: return "Total Conversion";
+                    default:                      return "Unrecognized";
                 }
             }
         }
@@ -102,6 +105,7 @@ namespace SilentHillPC_Launcher
         private string StatePath       { get { return Path.Combine(ModsDir, "modmanager.json"); } }
         private string ManifestPath    { get { return Path.Combine(ModsDir, "deployed.txt"); } }
         private string LoadOrderPath   { get { return Path.Combine(TexturemodsDir, "loadorder.txt"); } }
+        public  string BackupDir       { get { return Path.Combine(ModsDir, ".backup"); } }
 
         public List<ModEntry> Mods = new List<ModEntry>();
 
@@ -447,48 +451,77 @@ namespace SilentHillPC_Launcher
 
         private static ModType DetectType(string dir)
         {
-            bool hasVideo = false, hasFile = false;
+            bool hasDll = false, hasVideo = false, hasTexture = false, hasLoad = false, hasCfg = false, hasFile = false;
             foreach (var f in SafeFiles(dir))
             {
                 hasFile = true;
                 string n = Path.GetFileName(f).ToLowerInvariant();
-                if (n.EndsWith(".png") && (n.StartsWith("texupload-") || n.StartsWith("texpage-"))) return ModType.Texturemods;
-                if (n == "config.yaml") return ModType.Texturemods;
+                string ext = Path.GetExtension(f).ToLowerInvariant();
+
+                if (ext == ".dll") hasDll = true;
+                if (n.EndsWith(".png") && (n.StartsWith("texupload-") || n.StartsWith("texpage-"))) hasTexture = true;
+                if (n == "config.yaml") hasTexture = true;
                 if (IsVideoFile(n)) hasVideo = true;
+                if (n == "config.cfg" || n == "mod.cfg" || n == "preset.cfg") hasCfg = true;
+                if (f.Replace('\\', '/').ToLowerInvariant().Contains("/load/")) hasLoad = true;
             }
-            if (hasVideo) return ModType.Fmv;
-            if (FindDirNamed(dir, "load") != null) return ModType.Load;
-            if (hasFile) return ModType.Load;
+
+            if (FindDirNamed(dir, "load") != null) hasLoad = true;
+            if (FindDirNamed(dir, "maps") != null) hasDll = true;
+            if (FindDirNamed(dir, "plugins") != null) hasDll = true;
+
+            if (hasDll && (hasLoad || hasTexture || hasVideo)) return ModType.TotalConversion;
+            if (hasDll) return ModType.Gameplay;
+            if (hasVideo && !hasLoad && !hasTexture) return ModType.Fmv;
+            if (hasTexture && !hasLoad && !hasVideo) return ModType.Texturemods;
+            if (hasCfg && !hasLoad && !hasVideo && !hasTexture) return ModType.Preset;
+            if (hasLoad || hasFile) return ModType.Load;
             return ModType.Unknown;
         }
 
-        /// <summary>Detect a dropped path's type, peeking inside .zip archives. .rar and
-        /// .7z aren't peeked here so they're assumed a texture pack (the common case).</summary>
+        /// <summary>Detect a dropped path's type, peeking inside .zip archives.</summary>
         private static ModType DetectDroppedType(string path)
         {
             if (Directory.Exists(path)) return DetectType(path);
             string ext = Path.GetExtension(path).ToLowerInvariant();
-            if (ext == ".rar" || ext == ".7z") return ModType.Texturemods;
+            if (ext == ".rar" || ext == ".7z")
+            {
+                string fn = Path.GetFileName(path).ToLowerInvariant();
+                if (fn.Contains("gameplay") || fn.Contains("plugin") || fn.Contains("code") || fn.Contains("dll"))
+                    return ModType.Gameplay;
+                return ModType.Texturemods;
+            }
             if (ext == ".zip")
             {
                 try
                 {
                     using (var za = ZipFile.OpenRead(path))
                     {
-                        bool hasVideo = false;
+                        bool hasDll = false, hasVideo = false, hasTexture = false, hasLoad = false, hasCfg = false;
                         foreach (var en in za.Entries)
                         {
                             string n = Path.GetFileName(en.FullName).ToLowerInvariant();
-                            if (n.EndsWith(".png") && (n.StartsWith("texupload-") || n.StartsWith("texpage-"))) return ModType.Texturemods;
-                            if (n == "config.yaml") return ModType.Texturemods;
+                            string e = Path.GetExtension(en.FullName).ToLowerInvariant();
+
+                            if (e == ".dll") hasDll = true;
+                            if (n.EndsWith(".png") && (n.StartsWith("texupload-") || n.StartsWith("texpage-"))) hasTexture = true;
+                            if (n == "config.yaml") hasTexture = true;
                             if (IsVideoFile(n)) hasVideo = true;
-                            if (en.FullName.Replace('\\', '/').ToLowerInvariant().Contains("load/")) return ModType.Load;
+                            if (n == "config.cfg" || n == "mod.cfg" || n == "preset.cfg") hasCfg = true;
+                            if (en.FullName.Replace('\\', '/').ToLowerInvariant().Contains("load/")) hasLoad = true;
+                            if (en.FullName.Replace('\\', '/').ToLowerInvariant().Contains("maps/")) hasDll = true;
                         }
-                        if (hasVideo) return ModType.Fmv;
+
+                        if (hasDll && (hasLoad || hasTexture || hasVideo)) return ModType.TotalConversion;
+                        if (hasDll) return ModType.Gameplay;
+                        if (hasVideo && !hasLoad && !hasTexture) return ModType.Fmv;
+                        if (hasTexture && !hasLoad && !hasVideo) return ModType.Texturemods;
+                        if (hasCfg && !hasLoad && !hasTexture) return ModType.Preset;
+                        if (hasLoad) return ModType.Load;
                     }
                 }
                 catch { }
-                return ModType.Texturemods; // default: a .zip is usually a texture pack
+                return ModType.Texturemods; // default
             }
             return ModType.Unknown;
         }
@@ -688,7 +721,7 @@ namespace SilentHillPC_Launcher
 
         public class ApplyResult
         {
-            public int Texture, Load, Fmv, Files;
+            public int Texture, Load, Fmv, Gameplay, Preset, Files;
             public bool LooseEnabled;
             public List<string> Warnings = new List<string>();
         }
@@ -707,9 +740,6 @@ namespace SilentHillPC_Launcher
                     if (report != null) report(0, 0, "Enabling " + m.Label);
                     if (!EnableTexture(m, report, cancelled))
                     {
-                        // Leave it OFF: a pack whose unpack failed or was cancelled has no
-                        // .extracted folder, and listing it in loadorder.txt would point the
-                        // game at a directory that isn't there.
                         m.Enabled = false;
                         result.Warnings.Add(m.Label + (cancelled != null && cancelled()
                                                        ? ": unpack cancelled, left off"
@@ -737,26 +767,98 @@ namespace SilentHillPC_Launcher
                 try { File.Delete(LoadOrderPath); } catch { }
             }
 
-            // 3) Deploy load/FMV from the library (wipe + redeploy via manifest).
-            if (report != null) report(0, 0, "Deploying load/FMV mods…");
+            // 3) Deploy library mods (Gameplay, Load, FMV, TotalConversion, Preset)
+            if (report != null) report(0, 0, "Deploying mods…");
             Undeploy();
             var manifest = new List<string>();
 
+            // Gameplay & TotalConversion Mods (Code & DLLs)
+            var codeMods = Mods.Where(m => m.Source == ModSource.Library && m.Enabled && 
+                                         (m.Type == ModType.Gameplay || m.Type == ModType.TotalConversion)).ToList();
+            foreach (var m in Enumerable.Reverse(codeMods))
+            {
+                try
+                {
+                    result.Files += CopyGameplayTracked(m.LibraryPath, _gameRoot, manifest);
+                    result.Gameplay++;
+
+                    string loadSub = FindDirNamed(m.LibraryPath, "load");
+                    if (loadSub != null && Directory.Exists(loadSub))
+                    {
+                        result.Files += CopyTreeTracked(loadSub, LoadDir, manifest);
+                        result.Load++;
+                    }
+
+                    string fmvSub = FindDirNamed(m.LibraryPath, "FMV");
+                    if (fmvSub != null && Directory.Exists(fmvSub))
+                    {
+                        result.Files += CopyVideosFlat(fmvSub, FmvDir, manifest);
+                        result.Fmv++;
+                    }
+                }
+                catch (Exception ex) { result.Warnings.Add(m.Label + ": " + ex.Message); }
+            }
+
+            // Data Overlay (Load) Mods
             var loadMods = Mods.Where(m => m.Source == ModSource.Library && m.Enabled && m.Type == ModType.Load).ToList();
             foreach (var m in Enumerable.Reverse(loadMods))
             {
                 try { result.Files += CopyTreeTracked(DeploySourceRoot(m.LibraryPath, ModType.Load), LoadDir, manifest); result.Load++; }
                 catch (Exception ex) { result.Warnings.Add(m.Label + ": " + ex.Message); }
             }
+
+            // FMV Mods
             var fmvMods = Mods.Where(m => m.Source == ModSource.Library && m.Enabled && m.Type == ModType.Fmv).ToList();
             foreach (var m in Enumerable.Reverse(fmvMods))
             {
                 try { result.Files += CopyVideosFlat(m.LibraryPath, FmvDir, manifest); result.Fmv++; }
                 catch (Exception ex) { result.Warnings.Add(m.Label + ": " + ex.Message); }
             }
+
+            // Preset / Config Mods
+            var presetMods = Mods.Where(m => m.Source == ModSource.Library && m.Enabled && 
+                                           (m.Type == ModType.Preset || m.Type == ModType.TotalConversion)).ToList();
+            foreach (var m in Enumerable.Reverse(presetMods))
+            {
+                try
+                {
+                    string[] cfgCandidates = { "config.cfg", "mod.cfg", "preset.cfg" };
+                    foreach (var cName in cfgCandidates)
+                    {
+                        string cfgFile = Path.Combine(m.LibraryPath, cName);
+                        if (File.Exists(cfgFile))
+                        {
+                            string cfgBak = Path.Combine(BackupDir, "config.cfg.bak");
+                            string liveCfg = Path.Combine(_gameRoot, "config.cfg");
+                            if (!File.Exists(cfgBak) && File.Exists(liveCfg))
+                            {
+                                Directory.CreateDirectory(BackupDir);
+                                File.Copy(liveCfg, cfgBak, true);
+                            }
+
+                            foreach (var line in File.ReadAllLines(cfgFile))
+                            {
+                                var trimmed = line.Trim();
+                                if (string.IsNullOrEmpty(trimmed) || trimmed.StartsWith("#") || trimmed.StartsWith("//")) continue;
+                                int eq = trimmed.IndexOf('=');
+                                if (eq > 0)
+                                {
+                                    string k = trimmed.Substring(0, eq).Trim();
+                                    string v = trimmed.Substring(eq + 1).Trim();
+                                    _config.Set(k, v);
+                                }
+                            }
+                            result.Preset++;
+                            break;
+                        }
+                    }
+                }
+                catch (Exception ex) { result.Warnings.Add(m.Label + ": " + ex.Message); }
+            }
+
             WriteManifest(manifest);
 
-            bool loose = looseFileSupport || loadMods.Count > 0;
+            bool loose = looseFileSupport || loadMods.Count > 0 || codeMods.Count > 0;
             _config.Set("allow_loose_files", loose ? "1" : "0");
             _config.Save();
             result.LooseEnabled = loose;
@@ -765,7 +867,7 @@ namespace SilentHillPC_Launcher
             return result;
         }
 
-        // --- deploy plumbing (load/FMV) --------------------------------------
+        // --- deploy plumbing (load/FMV/gameplay) -----------------------------
 
         private void Undeploy()
         {
@@ -774,18 +876,61 @@ namespace SilentHillPC_Launcher
                 foreach (var line in File.ReadAllLines(ManifestPath))
                 {
                     if (line.Length < 3 || line[1] != '|') continue;
-                    string full = Path.Combine(_gameRoot, line.Substring(2));
+                    char op = line[0];
+                    string rel = line.Substring(2);
+                    string full = Path.Combine(_gameRoot, rel);
                     try
                     {
-                        if (line[0] == 'D' && Directory.Exists(full)) Directory.Delete(full, true);
-                        else if (line[0] == 'F' && File.Exists(full))  File.Delete(full);
+                        if (op == 'D' && Directory.Exists(full))
+                        {
+                            Directory.Delete(full, true);
+                        }
+                        else if (op == 'F' && File.Exists(full))
+                        {
+                            File.Delete(full);
+                        }
+                        else if (op == 'B') // Backed up file: restore from .backup/
+                        {
+                            string backupFile = Path.Combine(BackupDir, rel);
+                            if (File.Exists(backupFile))
+                            {
+                                Directory.CreateDirectory(Path.GetDirectoryName(full));
+                                File.Copy(backupFile, full, true);
+                                File.Delete(backupFile);
+                            }
+                            else if (File.Exists(full))
+                            {
+                                File.Delete(full);
+                            }
+                        }
                     }
                     catch { }
                 }
                 try { File.Delete(ManifestPath); } catch { }
             }
+
+            // Restore config backup if any
+            string cfgBak = Path.Combine(BackupDir, "config.cfg.bak");
+            if (File.Exists(cfgBak))
+            {
+                try
+                {
+                    string liveCfg = Path.Combine(_gameRoot, "config.cfg");
+                    File.Copy(cfgBak, liveCfg, true);
+                    File.Delete(cfgBak);
+                }
+                catch { }
+            }
+
+            if (Directory.Exists(BackupDir))
+            {
+                try { Directory.Delete(BackupDir, true); } catch { }
+            }
+
             PruneEmptyDirs(LoadDir);
             PruneEmptyDirs(FmvDir);
+            PruneEmptyDirs(Path.Combine(_gameRoot, "maps"));
+            PruneEmptyDirs(Path.Combine(_gameRoot, "plugins"));
         }
 
         private void WriteManifest(List<string> manifest)
@@ -842,6 +987,42 @@ namespace SilentHillPC_Launcher
                 File.Copy(files[i], files[i].Replace(src, dst), true);
             }
             return true;
+        }
+
+        private int CopyGameplayTracked(string src, string dstRoot, List<string> manifest)
+        {
+            int n = 0;
+            Directory.CreateDirectory(BackupDir);
+            foreach (var file in Directory.GetFiles(src, "*", SearchOption.AllDirectories))
+            {
+                string rel = file.Substring(src.Length).TrimStart('\\', '/');
+                string relLower = rel.ToLowerInvariant().Replace('\\', '/');
+
+                if (relLower == "modmanager.json" || relLower == "mod.json" || relLower == "readme.txt")
+                    continue;
+
+                string dst = Path.Combine(dstRoot, rel);
+                Directory.CreateDirectory(Path.GetDirectoryName(dst));
+
+                if (File.Exists(dst))
+                {
+                    string backupFile = Path.Combine(BackupDir, rel);
+                    if (!File.Exists(backupFile))
+                    {
+                        Directory.CreateDirectory(Path.GetDirectoryName(backupFile));
+                        File.Copy(dst, backupFile, true);
+                    }
+                    manifest.Add("B|" + Rel(dst));
+                }
+                else
+                {
+                    manifest.Add("F|" + Rel(dst));
+                }
+
+                File.Copy(file, dst, true);
+                n++;
+            }
+            return n;
         }
 
         private int CopyTreeTracked(string src, string dstRoot, List<string> manifest)

--- a/pc_port/launcher/SilentHillPC_Launcher/ModManagerForm.cs
+++ b/pc_port/launcher/SilentHillPC_Launcher/ModManagerForm.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -1487,9 +1487,9 @@ namespace SilentHillPC_Launcher
                 Populate(); // reflect enable/disable state changes
 
                 string msg = string.Format(
-                    "Applied.\n\nActive texture packs: {0}\nLoad-folder mods: {1}\nFMV mods: {2}\n" +
-                    "Loose file support: {3}",
-                    r.Texture, r.Load, r.Fmv, r.LooseEnabled ? "on" : "off");
+                    "Applied.\n\nActive texture packs: {0}\nData overlays (load/): {1}\nGameplay (Code / DLL) mods: {2}\nFMV video mods: {3}\nConfig presets: {4}\n" +
+                    "Loose file support: {5}",
+                    r.Texture, r.Load, r.Gameplay, r.Fmv, r.Preset, r.LooseEnabled ? "on" : "off");
                 if (r.Warnings.Count > 0)
                     msg += "\n\nWarnings:\n - " + string.Join("\n - ", r.Warnings);
 

--- a/pc_port/src/dll_security.c
+++ b/pc_port/src/dll_security.c
@@ -1,0 +1,277 @@
+/*
+ * dll_security.c — Static PE binary inspection & safety audit for PC port plugins.
+ *
+ * This file inspects .dll binaries on disk prior to calling LoadLibrary to prevent
+ * unauthorized execution of dangerous OS APIs (networking, process injection, shells)
+ * and ensure plugins strictly conform to the Silent Hill PC Port contract.
+ */
+#include "dll_security.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+/* Convert a Relative Virtual Address (RVA) to a file offset using Section Headers */
+static DWORD RvaToFileOffset(DWORD rva, IMAGE_SECTION_HEADER* sections, WORD numSections)
+{
+    for (WORD i = 0; i < numSections; i++)
+    {
+        DWORD secVA = sections[i].VirtualAddress;
+        DWORD secSize = sections[i].Misc.VirtualSize ? sections[i].Misc.VirtualSize : sections[i].SizeOfRawData;
+
+        if (rva >= secVA && rva < secVA + secSize)
+        {
+            return sections[i].PointerToRawData + (rva - secVA);
+        }
+    }
+    return 0;
+}
+
+static int StrCaseEqual(const char* a, const char* b)
+{
+    while (*a && *b)
+    {
+        if (tolower((unsigned char)*a) != tolower((unsigned char)*b))
+            return 0;
+        a++;
+        b++;
+    }
+    return *a == *b;
+}
+
+/* Blacklist of DLLs that a game plugin must NEVER import */
+static const char* s_blockedDlls[] = {
+    "ws2_32.dll",
+    "wsock32.dll",
+    "wininet.dll",
+    "urlmon.dll",
+    "winhttp.dll",
+    "shell32.dll",
+    NULL
+};
+
+DllSecurityResult DllSecurity_AuditPlugin(const char* path, char* outReason, int maxReasonLen)
+{
+    FILE* f = fopen(path, "rb");
+    if (!f)
+    {
+        if (outReason) snprintf(outReason, maxReasonLen, "Unable to open file for security audit");
+        return DLL_SECURITY_ERR_FILE_OPEN;
+    }
+
+    IMAGE_DOS_HEADER dosHeader;
+    if (fread(&dosHeader, sizeof(IMAGE_DOS_HEADER), 1, f) != 1 || dosHeader.e_magic != IMAGE_DOS_SIGNATURE)
+    {
+        fclose(f);
+        if (outReason) snprintf(outReason, maxReasonLen, "Invalid DOS header (not a valid PE binary)");
+        return DLL_SECURITY_ERR_INVALID_PE;
+    }
+
+    if (fseek(f, dosHeader.e_lfanew, SEEK_SET) != 0)
+    {
+        fclose(f);
+        if (outReason) snprintf(outReason, maxReasonLen, "Invalid PE offset");
+        return DLL_SECURITY_ERR_INVALID_PE;
+    }
+
+    DWORD peSignature = 0;
+    if (fread(&peSignature, sizeof(DWORD), 1, f) != 1 || peSignature != IMAGE_NT_SIGNATURE)
+    {
+        fclose(f);
+        if (outReason) snprintf(outReason, maxReasonLen, "Invalid NT signature");
+        return DLL_SECURITY_ERR_INVALID_PE;
+    }
+
+    IMAGE_FILE_HEADER fileHeader;
+    if (fread(&fileHeader, sizeof(IMAGE_FILE_HEADER), 1, f) != 1)
+    {
+        fclose(f);
+        if (outReason) snprintf(outReason, maxReasonLen, "Unable to read PE file header");
+        return DLL_SECURITY_ERR_INVALID_PE;
+    }
+
+    if (!(fileHeader.Characteristics & IMAGE_FILE_DLL))
+    {
+        fclose(f);
+        if (outReason) snprintf(outReason, maxReasonLen, "Binary is not a dynamic link library (DLL)");
+        return DLL_SECURITY_ERR_INVALID_PE;
+    }
+
+    WORD optMagic = 0;
+    if (fread(&optMagic, sizeof(WORD), 1, f) != 1)
+    {
+        fclose(f);
+        return DLL_SECURITY_ERR_INVALID_PE;
+    }
+    fseek(f, -((long)sizeof(WORD)), SEEK_CUR);
+
+    DWORD importRva = 0;
+    DWORD exportRva = 0;
+
+    if (optMagic == IMAGE_NT_OPTIONAL_HDR64_MAGIC)
+    {
+        IMAGE_OPTIONAL_HEADER64 optHeader64;
+        if (fread(&optHeader64, sizeof(IMAGE_OPTIONAL_HEADER64), 1, f) != 1)
+        {
+            fclose(f);
+            return DLL_SECURITY_ERR_INVALID_PE;
+        }
+        if (optHeader64.NumberOfRvaAndSizes > IMAGE_DIRECTORY_ENTRY_IMPORT)
+            importRva = optHeader64.DataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT].VirtualAddress;
+        if (optHeader64.NumberOfRvaAndSizes > IMAGE_DIRECTORY_ENTRY_EXPORT)
+            exportRva = optHeader64.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT].VirtualAddress;
+    }
+    else if (optMagic == IMAGE_NT_OPTIONAL_HDR32_MAGIC)
+    {
+        IMAGE_OPTIONAL_HEADER32 optHeader32;
+        if (fread(&optHeader32, sizeof(IMAGE_OPTIONAL_HEADER32), 1, f) != 1)
+        {
+            fclose(f);
+            return DLL_SECURITY_ERR_INVALID_PE;
+        }
+        if (optHeader32.NumberOfRvaAndSizes > IMAGE_DIRECTORY_ENTRY_IMPORT)
+            importRva = optHeader32.DataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT].VirtualAddress;
+        if (optHeader32.NumberOfRvaAndSizes > IMAGE_DIRECTORY_ENTRY_EXPORT)
+            exportRva = optHeader32.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT].VirtualAddress;
+    }
+    else
+    {
+        fclose(f);
+        if (outReason) snprintf(outReason, maxReasonLen, "Unsupported PE optional header magic");
+        return DLL_SECURITY_ERR_INVALID_PE;
+    }
+
+    /* Read Section Headers */
+    WORD numSections = fileHeader.NumberOfSections;
+    if (numSections == 0 || numSections > 96)
+    {
+        fclose(f);
+        return DLL_SECURITY_ERR_INVALID_PE;
+    }
+
+    IMAGE_SECTION_HEADER* sections = (IMAGE_SECTION_HEADER*)malloc(numSections * sizeof(IMAGE_SECTION_HEADER));
+    if (!sections)
+    {
+        fclose(f);
+        return DLL_SECURITY_ERR_FILE_OPEN;
+    }
+
+    if (fread(sections, sizeof(IMAGE_SECTION_HEADER), numSections, f) != numSections)
+    {
+        free(sections);
+        fclose(f);
+        return DLL_SECURITY_ERR_INVALID_PE;
+    }
+
+    /* 1. Audit Import Table for blocked/dangerous OS DLLs */
+    if (importRva != 0)
+    {
+        DWORD importOffset = RvaToFileOffset(importRva, sections, numSections);
+        if (importOffset != 0 && fseek(f, importOffset, SEEK_SET) == 0)
+        {
+            IMAGE_IMPORT_DESCRIPTOR desc;
+            while (fread(&desc, sizeof(IMAGE_IMPORT_DESCRIPTOR), 1, f) == 1 && desc.Name != 0)
+            {
+                long savedPos = ftell(f);
+                DWORD nameOffset = RvaToFileOffset(desc.Name, sections, numSections);
+                if (nameOffset != 0 && fseek(f, nameOffset, SEEK_SET) == 0)
+                {
+                    char dllName[128] = {0};
+                    if (fread(dllName, 1, sizeof(dllName) - 1, f) > 0)
+                    {
+                        dllName[sizeof(dllName) - 1] = '\0';
+                        for (int b = 0; s_blockedDlls[b] != NULL; b++)
+                        {
+                            if (StrCaseEqual(dllName, s_blockedDlls[b]))
+                            {
+                                free(sections);
+                                fclose(f);
+                                if (outReason)
+                                {
+                                    snprintf(outReason, maxReasonLen,
+                                             "Blocked dangerous library import: '%s' (networking/shell execution is prohibited)",
+                                             dllName);
+                                }
+                                return DLL_SECURITY_ERR_BLOCKED_IMPORT;
+                            }
+                        }
+                    }
+                }
+                fseek(f, savedPos, SEEK_SET);
+            }
+        }
+    }
+
+    /* 2. Audit Export Table for valid Silent Hill plugin symbols */
+    int hasValidPluginExport = 0;
+    if (exportRva != 0)
+    {
+        DWORD exportOffset = RvaToFileOffset(exportRva, sections, numSections);
+        if (exportOffset != 0 && fseek(f, exportOffset, SEEK_SET) == 0)
+        {
+            IMAGE_EXPORT_DIRECTORY expDir;
+            if (fread(&expDir, sizeof(IMAGE_EXPORT_DIRECTORY), 1, f) == 1)
+            {
+                DWORD namesOffset = RvaToFileOffset(expDir.AddressOfNames, sections, numSections);
+                if (namesOffset != 0 && fseek(f, namesOffset, SEEK_SET) == 0)
+                {
+                    DWORD numNames = expDir.NumberOfNames;
+                    if (numNames > 512) numNames = 512;
+
+                    DWORD* nameRvas = (DWORD*)malloc(numNames * sizeof(DWORD));
+                    if (nameRvas && fread(nameRvas, sizeof(DWORD), numNames, f) == numNames)
+                    {
+                        for (DWORD i = 0; i < numNames; i++)
+                        {
+                            DWORD funcNameOffset = RvaToFileOffset(nameRvas[i], sections, numSections);
+                            if (funcNameOffset != 0 && fseek(f, funcNameOffset, SEEK_SET) == 0)
+                            {
+                                char funcName[128] = {0};
+                                if (fread(funcName, 1, sizeof(funcName) - 1, f) > 0)
+                                {
+                                    funcName[sizeof(funcName) - 1] = '\0';
+                                    if (strncmp(funcName, "SH_Plugin_", 10) == 0)
+                                    {
+                                        hasValidPluginExport = 1;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if (nameRvas) free(nameRvas);
+                }
+            }
+        }
+    }
+
+    free(sections);
+    fclose(f);
+
+    if (!hasValidPluginExport)
+    {
+        if (outReason)
+        {
+            snprintf(outReason, maxReasonLen,
+                     "DLL does not implement the Silent Hill PC plugin interface (no SH_Plugin_* exports found)");
+        }
+        return DLL_SECURITY_ERR_NO_PLUGIN_EXPORTS;
+    }
+
+    if (outReason) snprintf(outReason, maxReasonLen, "Security audit passed (Valid Silent Hill plugin)");
+    return DLL_SECURITY_OK;
+}
+
+#else /* Non-Windows stub */
+
+DllSecurityResult DllSecurity_AuditPlugin(const char* path, char* outReason, int maxReasonLen)
+{
+    if (outReason) snprintf(outReason, maxReasonLen, "Audit passed (POSIX host)");
+    return DLL_SECURITY_OK;
+}
+
+#endif

--- a/pc_port/src/pc_plugins.c
+++ b/pc_port/src/pc_plugins.c
@@ -1,0 +1,147 @@
+#include "pc_plugins.h"
+#include "dll_loader.h"
+#include "dll_security.h"
+#include "sh_log.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_PLUGINS 32
+
+typedef struct
+{
+    char                        name[128];
+    DllHandle                   handle;
+    SH_Plugin_InitFunc          initFunc;
+    SH_Plugin_ShutdownFunc      shutdownFunc;
+    SH_Plugin_NewGameFunc       newGameFunc;
+    SH_Plugin_MapLoadFunc       mapLoadFunc;
+    SH_Plugin_UpdateFunc        updateFunc;
+    SH_Plugin_RenderFunc        renderFunc;
+    SH_Plugin_GetNameFunc       getNameFunc;
+    SH_Plugin_GetApiVersionFunc getApiVersionFunc;
+} PluginEntry;
+
+static PluginEntry s_plugins[MAX_PLUGINS];
+static int         s_pluginCount = 0;
+static int         s_initialized = 0;
+
+void Pc_Plugins_Init(void)
+{
+    if (s_initialized) return;
+    s_initialized = 1;
+    s_pluginCount = 0;
+
+    SH_LOG("[PLUGINS] Scanning for plugin DLLs in plugins/ ...");
+
+    char pluginPaths[MAX_PLUGINS][260];
+    int foundCount = DllLoader_ListPlugins(pluginPaths, MAX_PLUGINS);
+
+    for (int i = 0; i < foundCount; i++)
+    {
+        const char* path = pluginPaths[i];
+
+        /* Pre-execution static binary security audit */
+        char auditReason[256] = {0};
+        DllSecurityResult secResult = DllSecurity_AuditPlugin(path, auditReason, sizeof(auditReason));
+        if (secResult != DLL_SECURITY_OK)
+        {
+            SH_LOG("[SECURITY] ❌ REJECTED plugin '%s': %s", path, auditReason);
+            continue;
+        }
+        SH_LOG("[SECURITY] ✔ VERIFIED plugin '%s': %s", path, auditReason);
+
+        DllHandle handle = DllLoader_Open(path);
+        if (handle)
+        {
+            PluginEntry* p = &s_plugins[s_pluginCount];
+            strncpy(p->name, path, sizeof(p->name) - 1);
+            p->handle            = handle;
+            p->initFunc          = (SH_Plugin_InitFunc)DllLoader_GetSymbol(handle, "SH_Plugin_Init");
+            p->shutdownFunc      = (SH_Plugin_ShutdownFunc)DllLoader_GetSymbol(handle, "SH_Plugin_Shutdown");
+            p->newGameFunc       = (SH_Plugin_NewGameFunc)DllLoader_GetSymbol(handle, "SH_Plugin_OnNewGame");
+            p->mapLoadFunc       = (SH_Plugin_MapLoadFunc)DllLoader_GetSymbol(handle, "SH_Plugin_OnMapLoad");
+            p->updateFunc        = (SH_Plugin_UpdateFunc)DllLoader_GetSymbol(handle, "SH_Plugin_OnUpdate");
+            p->renderFunc        = (SH_Plugin_RenderFunc)DllLoader_GetSymbol(handle, "SH_Plugin_OnRender");
+            p->getNameFunc       = (SH_Plugin_GetNameFunc)DllLoader_GetSymbol(handle, "SH_Plugin_GetName");
+            p->getApiVersionFunc = (SH_Plugin_GetApiVersionFunc)DllLoader_GetSymbol(handle, "SH_Plugin_GetApiVersion");
+
+            const char* displayName = p->getNameFunc ? p->getNameFunc() : path;
+            SH_LOG("[PLUGINS] Loaded plugin: %s", displayName);
+
+            if (p->initFunc)
+            {
+                p->initFunc();
+            }
+            s_pluginCount++;
+        }
+        else
+        {
+            SH_LOG("[PLUGINS] Failed to load plugin %s (%s)", path, DllLoader_GetError());
+        }
+    }
+
+    SH_LOG("[PLUGINS] Active plugins: %d", s_pluginCount);
+}
+
+void Pc_Plugins_Shutdown(void)
+{
+    for (int i = 0; i < s_pluginCount; i++)
+    {
+        if (s_plugins[i].shutdownFunc)
+        {
+            s_plugins[i].shutdownFunc();
+        }
+        if (s_plugins[i].handle)
+        {
+            DllLoader_Close(s_plugins[i].handle);
+            s_plugins[i].handle = NULL;
+        }
+    }
+    s_pluginCount = 0;
+    s_initialized = 0;
+}
+
+void Pc_Plugins_OnNewGame(void)
+{
+    for (int i = 0; i < s_pluginCount; i++)
+    {
+        if (s_plugins[i].newGameFunc)
+        {
+            s_plugins[i].newGameFunc();
+        }
+    }
+}
+
+void Pc_Plugins_OnMapLoad(s32 mapIdx)
+{
+    for (int i = 0; i < s_pluginCount; i++)
+    {
+        if (s_plugins[i].mapLoadFunc)
+        {
+            s_plugins[i].mapLoadFunc(mapIdx);
+        }
+    }
+}
+
+void Pc_Plugins_OnUpdate(void)
+{
+    for (int i = 0; i < s_pluginCount; i++)
+    {
+        if (s_plugins[i].updateFunc)
+        {
+            s_plugins[i].updateFunc();
+        }
+    }
+}
+
+void Pc_Plugins_OnRender(void)
+{
+    for (int i = 0; i < s_pluginCount; i++)
+    {
+        if (s_plugins[i].renderFunc)
+        {
+            s_plugins[i].renderFunc();
+        }
+    }
+}


### PR DESCRIPTION
This PR updates the modding infrastructure for the Silent Hill PC Port with a revamped Mod Manager and a static security check for native DLL plugins.

Changes
Mod Manager
Added support for gamedata/load replacements and gameplay plugins.
Added automatic extraction for .zip, .rar, and .7z archives.
Added loadorder.txt support for controlling mod priority.
Added deployed.txt manifests to track installed files and allow clean uninstalls.
Added drag-and-drop installation.
DLL Security
Added DllSecurity_AuditPlugin() in pc_port/src/dll_security.c.
DLLs are inspected on disk before LoadLibraryA() is called.
Added checks for network-related imports such as ws2_32.dll, wininet.dll, urlmon.dll, and winhttp.dll.
Added checks for shell/process-related imports such as ShellExecute, CreateProcess, and VirtualAllocEx.
Added validation for the required SH_Plugin_* exports.
Standardized the plugin lifecycle around Init, Shutdown, NewGame, MapLoad, Update, Render, GetName, and GetApiVersion.
Testing
Tested with existing DLL plugins and confirmed they pass the security checks and load normally.
Verified the changes build correctly through the existing CMake and C# launcher pipelines.